### PR TITLE
chore: publish to npm with trusted publishing instead of a token

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,8 +12,9 @@ concurrency:
 permissions:
   contents: write
   pull-requests: write
-  # Required for npm provenance, which signs the published tarball with a
-  # verifiable link back to this workflow run.
+  # Required for npm trusted publishing: npm exchanges this workflow's OIDC
+  # token for a short-lived publish token, so no npm token is stored anywhere.
+  # The same OIDC identity is what signs the provenance attestation.
   id-token: write
 
 env:
@@ -29,11 +30,19 @@ jobs:
         with:
           fetch-depth: 0
 
+      # No registry-url on purpose: it writes an .npmrc pinning the auth token
+      # to NODE_AUTH_TOKEN, and trusted publishing authenticates over OIDC
+      # instead. Leaving it would point npm at an unset variable.
       - name: Set up Node.js ${{ env.NODE_VERSION }}
         uses: actions/setup-node@v7
         with:
           node-version: ${{ env.NODE_VERSION }}
-          registry-url: 'https://registry.npmjs.org'
+
+      # Trusted publishing landed in npm 11.5.1 and Node 22 still bundles
+      # npm 10, so upgrade npm rather than the Node version — the release job
+      # then builds on the same runtime CI tests against.
+      - name: Update npm
+        run: npm install -g npm@latest
 
       - name: Install dependencies
         run: npm ci
@@ -57,5 +66,8 @@ jobs:
           commit: 'chore: release'
         env:
           GITHUB_TOKEN: ${{ secrets.RELEASE_TOKEN || secrets.GITHUB_TOKEN }}
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          # npm authenticates over OIDC against the trusted publisher
+          # configured for this package (this repository, this workflow file),
+          # so there is deliberately no npm token here. Provenance is implied by
+          # trusted publishing; the flag is kept so the intent stays explicit.
           NPM_CONFIG_PROVENANCE: true


### PR DESCRIPTION
## Why

The 0.5.0 release has failed twice on the publish step. The first run failed with `E404` on `PUT` — npm's way of saying the token had no write access to the package. After the token was replaced, the second run got further and failed with:

```
npm error code EOTP
npm error This operation requires a one-time password from your authenticator.
```

`E404` → `EOTP` means the new token does have write access. npm is now rejecting the publish because the account requires 2FA and this token does not bypass it, which CI cannot satisfy. Regenerating it as a 2FA-bypass token would work today, but npm is deprecating those for direct publishing, so it only defers the problem.

## What

Switches the release job to npm trusted publishing, which authenticates over the workflow's OIDC identity — no token to store, and nothing to rotate every 90 days.

- Drops `NODE_AUTH_TOKEN` from the publish step.
- Drops `registry-url` from `actions/setup-node`. These have to go together: `registry-url` writes an `.npmrc` pinning the auth token to `NODE_AUTH_TOKEN`, and leaving it behind would point npm at an unset variable.
- Adds an `npm install -g npm@latest` step. The OIDC support landed in npm 11.5.1 and Node 22 bundles npm 10.9.8. Upgrading npm keeps the release job on the same Node version CI tests against, rather than introducing a Node 24 runtime that nothing else exercises.
- `id-token: write` was already present for provenance and is what trusted publishing uses. `NPM_CONFIG_PROVENANCE` is now implied but kept so the intent stays explicit.

`changesets/action@v1` needs no change — the OIDC exchange is done by the npm CLI itself, not by the action.

## Before merging

The trusted publisher must be configured on npmjs.com first (package settings → Trusted Publisher → GitHub Actions, repo `smartcompanion-app/native-audio-player`, workflow `release.yml`, no environment). Merging ahead of that will fail the same way again.

Once merged, the release workflow runs against `main` — which is already at 0.5.0 with no changesets pending — and publishes 0.5.0, tags it, and creates the GitHub release. No changeset is needed here; this is CI-only and not user-visible.
