### PR TITLE
chore: stop double CI runs and ignore Gradle wrapper majors

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -31,12 +31,16 @@ updates:
 
   # Android tooling is pinned to what @capacitor/android builds against, so
   # majors here need a deliberate decision rather than an automatic bump.
+  # Gradle 9.6 dropped an internal API that AGP 8.x still uses, so the wrapper
+  # cannot move to 9.x while AGP is held at 8.13 -- see #18 and #19.
   - package-ecosystem: gradle
     directory: /android
     schedule:
       interval: monthly
     ignore:
       - dependency-name: com.android.tools.build:gradle
+        update-types: [version-update:semver-major]
+      - dependency-name: gradle-wrapper
         update-types: [version-update:semver-major]
 
   - package-ecosystem: gradle
@@ -45,6 +49,8 @@ updates:
       interval: monthly
     ignore:
       - dependency-name: com.android.tools.build:gradle
+        update-types: [version-update:semver-major]
+      - dependency-name: gradle-wrapper
         update-types: [version-update:semver-major]
 
   - package-ecosystem: github-actions

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,12 @@
 name: ci
 
+# Pushes are only built for main. A push to any other branch that has a PR open
+# would otherwise be built twice -- once for the push, once for the pull_request.
 on:
-  - push
-  - pull_request
+  push:
+    branches:
+      - main
+  pull_request:
 
 permissions:
   contents: read


### PR DESCRIPTION
Follow-up to the Dependabot sweep.

## CI ran twice for every PR

`ci.yml` triggered on both `push` and `pull_request`. Any branch with an open PR built the entire matrix twice — including two iOS jobs at 10–20 minutes each on `macos-15`, plus two Android emulator jobs. Every Dependabot PR in this batch shows two full sets of checks.

Pushes now only build `main`; PR branches are covered by the `pull_request` trigger.

## Dependabot kept proposing an impossible Gradle bump

The gradle blocks ignored `com.android.tools.build:gradle` majors but not `gradle-wrapper`, so #18 and #19 proposed Gradle 8.14.3 → 9.6.1. That combination cannot build:

> Plugin 'com.android.internal.library' relies on 'org.gradle.api.problems.internal.InternalProblems', a Gradle internal API that was removed in Gradle 9.6.0. Update the plugin to a version that no longer uses Gradle internal APIs, or use Gradle 9.5.

AGP is pinned to 8.13.x to match `@capacitor/android`, so the wrapper can't move to 9.x until Capacitor moves to AGP 9. Both PRs are closed and wrapper majors are now ignored for the same reason AGP majors already were.

No changeset — build and CI config only, nothing user-visible.