### PR TITLE
fix: crashes and memory leaks in the iOS and Android players

### DIFF
--- a/.changeset/olive-poets-repeat.md
+++ b/.changeset/olive-poets-repeat.md
@@ -1,0 +1,22 @@
+---
+'@smartcompanion/native-audio-player': patch
+---
+
+Fix crashes and memory leaks in the iOS and Android players.
+
+**iOS**
+
+- Calling any method before `start()` no longer crashes. `stop()`, `play()`, `pause()`, `select()`, `next()`, `previous()`, `setEarpiece()` and `setSpeaker()` all read through a bounds-checked accessor instead of indexing an empty playlist, and `start({items: []})` now rejects instead of trapping.
+- An item whose `imageUri` is missing or undecodable no longer crashes. The lock screen artwork is decoded up front and omitted when it cannot be loaded, rather than being force unwrapped inside a handler the system invokes on an arbitrary thread.
+- The plugin is no longer leaked for the lifetime of the app. The `onCompleted` callback and the five `MPRemoteCommandCenter` handlers now capture `self` weakly, the handlers are removed on `stop()` and in `deinit`, and targets belonging to the host app or other plugins are left alone (`removeTarget(nil)` removes *every* target for a command).
+- `audioUri` and `imageUri` are honored in full. Previously only the last path component survived and was re-rooted in the documents directory, which happened to work for `Directory.Data` but broke for nested paths, `Directory.Cache` and `Directory.Library`. Plain paths and `file://` URLs are both accepted, matching Android and the web implementation.
+
+**Android**
+
+- `stop()` now removes the player listener. It was being unregistered after the controller field had already been nulled, so the guard inside `unregisterPlayerEvents()` short circuited and the listener was never detached.
+- `stop()` always answers its call. An exception used to be logged and swallowed, leaving the promise pending forever.
+- A second `start()` no longer leaks the previous `MediaController` or registers a duplicate listener, which caused every `update` event to be delivered twice.
+- The `MediaController` callback runs on the main thread, as `MediaController` requires, instead of on whichever thread completed the future.
+- A null media item in `onMediaItemTransition` is handled properly. The `assert` that was meant to guard it is disabled at runtime on Android.
+- `getPosition()` always resolves with a `value`. It previously resolved with an empty object when no controller existed, reaching JS as `undefined` where iOS and the web return `0`.
+- `select()`, `next()` and `previous()` resolve with `{id}` as the TypeScript definitions declare, instead of an empty object.

--- a/.changeset/olive-poets-repeat.md
+++ b/.changeset/olive-poets-repeat.md
@@ -8,7 +8,7 @@ Fix crashes and memory leaks in the iOS and Android players.
 
 - Calling any method before `start()` no longer crashes. `stop()`, `play()`, `pause()`, `select()`, `next()`, `previous()`, `setEarpiece()` and `setSpeaker()` all read through a bounds-checked accessor instead of indexing an empty playlist, and `start({items: []})` now rejects instead of trapping.
 - An item whose `imageUri` is missing or undecodable no longer crashes. The lock screen artwork is decoded up front and omitted when it cannot be loaded, rather than being force unwrapped inside a handler the system invokes on an arbitrary thread.
-- The plugin is no longer leaked for the lifetime of the app. The `onCompleted` callback and the five `MPRemoteCommandCenter` handlers now capture `self` weakly, the handlers are removed on `stop()` and in `deinit`, and targets belonging to the host app or other plugins are left alone (`removeTarget(nil)` removes *every* target for a command).
+- The plugin is no longer leaked for the lifetime of the app. The `onCompleted` callback and the five `MPRemoteCommandCenter` handlers now capture `self` weakly, the handlers are removed on `stop()`, on a failed `start()` and in `deinit`, and targets belonging to the host app or other plugins are left alone (`removeTarget(nil)` removes *every* target for a command).
 - `audioUri` and `imageUri` are honored in full. Previously only the last path component survived and was re-rooted in the documents directory, which happened to work for `Directory.Data` but broke for nested paths, `Directory.Cache` and `Directory.Library`. Plain paths and `file://` URLs are both accepted, matching Android and the web implementation.
 
 **Android**
@@ -16,7 +16,7 @@ Fix crashes and memory leaks in the iOS and Android players.
 - `stop()` now removes the player listener. It was being unregistered after the controller field had already been nulled, so the guard inside `unregisterPlayerEvents()` short circuited and the listener was never detached.
 - `stop()` always answers its call. An exception used to be logged and swallowed, leaving the promise pending forever.
 - A second `start()` no longer leaks the previous `MediaController` or registers a duplicate listener, which caused every `update` event to be delivered twice.
-- The `MediaController` callback runs on the main thread, as `MediaController` requires, instead of on whichever thread completed the future.
+- A `start()` that fails after the controller connected releases that controller instead of leaving it assigned with its listener attached.
 - A null media item in `onMediaItemTransition` is handled properly. The `assert` that was meant to guard it is disabled at runtime on Android.
 - `getPosition()` always resolves with a `value`. It previously resolved with an empty object when no controller existed, reaching JS as `undefined` where iOS and the web return `0`.
-- `select()`, `next()` and `previous()` resolve with `{id}` as the TypeScript definitions declare, instead of an empty object.
+- `select()`, `next()` and `previous()` resolve with `{id}` as the TypeScript definitions declare, instead of an empty object. When no item is loaded they reject, as they already did on iOS, rather than resolving with an `undefined` id.

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -55,6 +55,9 @@ dependencies {
     implementation "androidx.appcompat:appcompat:$androidxAppCompatVersion"
     testImplementation "junit:junit:$junitVersion"
     testImplementation "org.robolectric:robolectric:4.16.1"
+    // every MediaController method the plugin calls is final, so the tests need
+    // Mockito 5's inline mock maker to stand one in
+    testImplementation "org.mockito:mockito-core:5.20.0"
     androidTestImplementation "androidx.test.ext:junit:$androidxJunitVersion"
     androidTestImplementation "androidx.test.espresso:espresso-core:$androidxEspressoCoreVersion"
 

--- a/android/src/main/java/app/smartcompanion/audio/NativeAudioPlayer.java
+++ b/android/src/main/java/app/smartcompanion/audio/NativeAudioPlayer.java
@@ -7,7 +7,6 @@ import androidx.media3.common.MediaMetadata;
 import com.getcapacitor.JSObject;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Objects;
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -23,8 +22,9 @@ public class NativeAudioPlayer {
                 mediaItems.add(getMediaItem(items.getJSONObject(i)));
             }
         } catch (Exception e) {
-            Log.e("NATIVE_AUDIO_PLAYER", "Could not transform JSON to MediaItems");
-            Log.e("NATIVE_AUDIO_PLAYER", Objects.requireNonNull(e.getMessage()));
+            // requireNonNull here used to throw straight back out of the catch block
+            // whenever the underlying exception carried no message
+            Log.e("NATIVE_AUDIO_PLAYER", "Could not transform JSON to MediaItems", e);
         }
 
         return mediaItems;

--- a/android/src/main/java/app/smartcompanion/audio/NativeAudioPlayerPlugin.java
+++ b/android/src/main/java/app/smartcompanion/audio/NativeAudioPlayerPlugin.java
@@ -6,6 +6,7 @@ import android.content.Context;
 import android.os.Bundle;
 import android.util.Log;
 import androidx.annotation.Nullable;
+import androidx.core.content.ContextCompat;
 import androidx.media3.common.MediaItem;
 import androidx.media3.common.Player;
 import androidx.media3.session.MediaController;
@@ -18,7 +19,6 @@ import com.getcapacitor.PluginMethod;
 import com.getcapacitor.annotation.CapacitorPlugin;
 import com.getcapacitor.annotation.Permission;
 import com.google.common.util.concurrent.ListenableFuture;
-import com.google.common.util.concurrent.MoreExecutors;
 import java.util.List;
 import java.util.Objects;
 
@@ -45,15 +45,27 @@ public class NativeAudioPlayerPlugin extends Plugin {
     protected Player.Listener playerListener = new Player.Listener() {
         @Override
         public void onMediaItemTransition(@Nullable MediaItem mediaItem, int reason) {
+            MediaController controller = mediaController;
+
+            // a transition can still be delivered once the controller is gone
+            if (controller == null) {
+                return;
+            }
+
             if (Player.MEDIA_ITEM_TRANSITION_REASON_AUTO == reason) {
-                mediaController.pause();
-                mediaController.seekToPreviousMediaItem();
+                controller.pause();
+                controller.seekToPreviousMediaItem();
+            }
+
+            // Java assertions are disabled at runtime on Android, so the assert
+            // this replaces never actually checked anything
+            if (mediaItem == null) {
+                return;
             }
 
             try {
-                assert mediaItem != null;
                 JSObject json = nativeAudioPlayer.prepareUpdateEvent("skip", mediaItem);
-                mediaController.pause();
+                controller.pause();
                 notifyListeners("update", json);
             } catch (Exception e) {
                 Log.e("NATIVE_AUDIO_PLAYER", "Could not trigger skip event: " + e.getMessage());
@@ -99,41 +111,68 @@ public class NativeAudioPlayerPlugin extends Plugin {
     @PluginMethod
     public void start(PluginCall call) {
         Context context = this.getContext();
+
+        // without this a second start() leaks the previous controller and leaves
+        // its listener attached, so every update event is delivered twice
+        releaseController();
+
         SessionToken sessionToken = new SessionToken(context, new ComponentName(context, AudioPlayerService.class));
         ListenableFuture<MediaController> controllerFuture = new MediaController.Builder(context, sessionToken).buildAsync();
 
         mediaItems = nativeAudioPlayer.fromJson(call.getData());
 
-        controllerFuture.addListener(() -> {
-            try {
-                mediaController = controllerFuture.get();
-                //mediaController.setRepeatMode(Player.REPEAT_MODE_OFF);
-                mediaController.setMediaItems(mediaItems);
+        controllerFuture.addListener(
+            () -> {
+                try {
+                    mediaController = controllerFuture.get();
+                    //mediaController.setRepeatMode(Player.REPEAT_MODE_OFF);
+                    mediaController.setMediaItems(mediaItems);
 
-                registerPlayerEvents();
-                call.resolve(nativeAudioPlayer.prepareIdItem(Objects.requireNonNull(mediaController.getCurrentMediaItem())));
-            } catch (Exception e) {
-                Log.e("NATIVE_AUDIO_PLAYER", "Could not create media player: " + e.getMessage());
-                call.reject("Could not create media player");
-            }
-        }, MoreExecutors.directExecutor());
+                    registerPlayerEvents();
+                    call.resolve(nativeAudioPlayer.prepareIdItem(Objects.requireNonNull(mediaController.getCurrentMediaItem())));
+                } catch (Exception e) {
+                    Log.e("NATIVE_AUDIO_PLAYER", "Could not create media player: " + e.getMessage());
+                    call.reject("Could not create media player");
+                }
+            },
+            // MediaController is main thread only, and directExecutor() would run
+            // this on whichever thread happened to complete the future
+            ContextCompat.getMainExecutor(context)
+        );
     }
 
     @PluginMethod
     public void stop(PluginCall call) {
+        String failure = null;
+
         try {
             if (mediaController != null) {
                 mediaController.pause();
                 mediaController.stop();
-                mediaController.release();
-                mediaController = null;
-                unregisterPlayerEvents();
-            }
-            if (call != null) {
-                call.resolve();
             }
         } catch (Exception e) {
             Log.e("NATIVE_AUDIO_PLAYER", "Native Audio Player stop: " + e.getMessage());
+            failure = "Could not stop the audio player";
+        }
+
+        // released in its own block so a failed pause/stop cannot leak the controller
+        try {
+            releaseController();
+        } catch (Exception e) {
+            Log.e("NATIVE_AUDIO_PLAYER", "Could not release the media controller: " + e.getMessage());
+            mediaController = null;
+            failure = "Could not stop the audio player";
+        }
+
+        mediaItems = null;
+
+        // any exception used to be logged and swallowed, hanging the promise in JS
+        if (call != null) {
+            if (failure != null) {
+                call.reject(failure);
+            } else {
+                call.resolve();
+            }
         }
     }
 
@@ -157,7 +196,7 @@ public class NativeAudioPlayerPlugin extends Plugin {
     public void select(PluginCall call) {
         String id = call.getString("id");
 
-        if (mediaController != null && id != null && mediaController.getMediaItemCount() > 0) {
+        if (mediaController != null && id != null) {
             for (int i = 0; i < mediaController.getMediaItemCount(); i++) {
                 MediaItem mediaItem = mediaController.getMediaItemAt(i);
 
@@ -167,7 +206,8 @@ public class NativeAudioPlayerPlugin extends Plugin {
                 }
             }
         }
-        call.resolve();
+
+        resolveWithCurrentId(call);
     }
 
     @PluginMethod
@@ -175,7 +215,7 @@ public class NativeAudioPlayerPlugin extends Plugin {
         if (mediaController != null) {
             mediaController.seekToNextMediaItem();
         }
-        call.resolve();
+        resolveWithCurrentId(call);
     }
 
     @PluginMethod
@@ -183,7 +223,7 @@ public class NativeAudioPlayerPlugin extends Plugin {
         if (mediaController != null) {
             mediaController.seekToPreviousMediaItem();
         }
-        call.resolve();
+        resolveWithCurrentId(call);
     }
 
     @PluginMethod
@@ -199,9 +239,9 @@ public class NativeAudioPlayerPlugin extends Plugin {
     @PluginMethod
     public void getPosition(PluginCall call) {
         JSObject result = new JSObject();
-        if (mediaController != null) {
-            result.put("value", mediaController.getCurrentPosition() / 1000);
-        }
+        // always carry a value: an absent key reaches JS as undefined, where iOS
+        // and the web implementation both report 0
+        result.put("value", mediaController != null ? mediaController.getCurrentPosition() / 1000 : 0);
         call.resolve(result);
     }
 
@@ -236,9 +276,40 @@ public class NativeAudioPlayerPlugin extends Plugin {
         call.resolve();
     }
 
+    /**
+     * Resolves with the id of the item the controller is on, matching the
+     * {id: string} the TypeScript definitions promise for these methods.
+     */
+    protected void resolveWithCurrentId(PluginCall call) {
+        MediaItem mediaItem = mediaController != null ? mediaController.getCurrentMediaItem() : null;
+
+        if (mediaItem == null) {
+            call.resolve();
+            return;
+        }
+
+        try {
+            call.resolve(nativeAudioPlayer.prepareIdItem(mediaItem));
+        } catch (Exception e) {
+            Log.e("NATIVE_AUDIO_PLAYER", "Could not read the current item id: " + e.getMessage());
+            call.resolve();
+        }
+    }
+
+    protected void releaseController() {
+        if (mediaController != null) {
+            // unregister while the controller is still reachable -- doing this after
+            // the field was nulled meant the guard below short circuited and the
+            // listener was never actually removed
+            unregisterPlayerEvents();
+            mediaController.release();
+            mediaController = null;
+        }
+    }
+
     protected void registerPlayerEvents() {
         if (mediaController != null) {
-            // mediaController.removeListener(this.playerListener); // prevent double add
+            mediaController.removeListener(this.playerListener); // prevent double add
             mediaController.addListener(this.playerListener);
         }
     }

--- a/android/src/main/java/app/smartcompanion/audio/NativeAudioPlayerPlugin.java
+++ b/android/src/main/java/app/smartcompanion/audio/NativeAudioPlayerPlugin.java
@@ -6,7 +6,6 @@ import android.content.Context;
 import android.os.Bundle;
 import android.util.Log;
 import androidx.annotation.Nullable;
-import androidx.core.content.ContextCompat;
 import androidx.media3.common.MediaItem;
 import androidx.media3.common.Player;
 import androidx.media3.session.MediaController;
@@ -19,8 +18,10 @@ import com.getcapacitor.PluginMethod;
 import com.getcapacitor.annotation.CapacitorPlugin;
 import com.getcapacitor.annotation.Permission;
 import com.google.common.util.concurrent.ListenableFuture;
+import com.google.common.util.concurrent.MoreExecutors;
 import java.util.List;
 import java.util.Objects;
+import java.util.concurrent.Future;
 
 @CapacitorPlugin(
     name = "NativeAudioPlayer",
@@ -122,23 +123,43 @@ public class NativeAudioPlayerPlugin extends Plugin {
         mediaItems = nativeAudioPlayer.fromJson(call.getData());
 
         controllerFuture.addListener(
-            () -> {
-                try {
-                    mediaController = controllerFuture.get();
-                    //mediaController.setRepeatMode(Player.REPEAT_MODE_OFF);
-                    mediaController.setMediaItems(mediaItems);
-
-                    registerPlayerEvents();
-                    call.resolve(nativeAudioPlayer.prepareIdItem(Objects.requireNonNull(mediaController.getCurrentMediaItem())));
-                } catch (Exception e) {
-                    Log.e("NATIVE_AUDIO_PLAYER", "Could not create media player: " + e.getMessage());
-                    call.reject("Could not create media player");
-                }
-            },
-            // MediaController is main thread only, and directExecutor() would run
-            // this on whichever thread happened to complete the future
-            ContextCompat.getMainExecutor(context)
+            () -> attachController(controllerFuture, call),
+            // A MediaController may only be touched from the looper it was built on,
+            // which is the "CapacitorPlugins" thread every @PluginMethod runs on, and
+            // buildAsync() completes the future on that same looper. directExecutor()
+            // therefore keeps us on the right thread -- handing this to the main
+            // executor instead makes every controller call throw.
+            MoreExecutors.directExecutor()
         );
+    }
+
+    /**
+     * Hands the connected controller the playlist and answers the call. Split out of
+     * the connection callback so the failure path is reachable from a test.
+     */
+    protected void attachController(Future<MediaController> controllerFuture, PluginCall call) {
+        try {
+            mediaController = controllerFuture.get();
+            //mediaController.setRepeatMode(Player.REPEAT_MODE_OFF);
+            mediaController.setMediaItems(mediaItems);
+
+            registerPlayerEvents();
+            call.resolve(nativeAudioPlayer.prepareIdItem(Objects.requireNonNull(mediaController.getCurrentMediaItem())));
+        } catch (Exception e) {
+            Log.e("NATIVE_AUDIO_PLAYER", "Could not create media player: " + e.getMessage());
+
+            // a half configured controller must not stay assigned: it keeps its
+            // listener attached and its connection to the session open
+            try {
+                releaseController();
+            } catch (Exception releaseError) {
+                Log.e("NATIVE_AUDIO_PLAYER", "Could not release the media controller: " + releaseError.getMessage());
+                mediaController = null;
+            }
+
+            mediaItems = null;
+            call.reject("Could not create media player");
+        }
     }
 
     @PluginMethod
@@ -278,13 +299,16 @@ public class NativeAudioPlayerPlugin extends Plugin {
 
     /**
      * Resolves with the id of the item the controller is on, matching the
-     * {id: string} the TypeScript definitions promise for these methods.
+     * {id: string} the TypeScript definitions promise for these methods. Without a
+     * current item there is no id to report, so the call is rejected rather than
+     * resolved with an empty object -- that would reach JS as an undefined id. iOS
+     * rejects the same three methods when it cannot switch item.
      */
     protected void resolveWithCurrentId(PluginCall call) {
         MediaItem mediaItem = mediaController != null ? mediaController.getCurrentMediaItem() : null;
 
         if (mediaItem == null) {
-            call.resolve();
+            call.reject("No audio item is loaded");
             return;
         }
 
@@ -292,7 +316,7 @@ public class NativeAudioPlayerPlugin extends Plugin {
             call.resolve(nativeAudioPlayer.prepareIdItem(mediaItem));
         } catch (Exception e) {
             Log.e("NATIVE_AUDIO_PLAYER", "Could not read the current item id: " + e.getMessage());
-            call.resolve();
+            call.reject("Could not read the current item id");
         }
     }
 

--- a/android/src/test/java/app/smartcompanion/audio/NativeAudioPlayerPluginTest.java
+++ b/android/src/test/java/app/smartcompanion/audio/NativeAudioPlayerPluginTest.java
@@ -14,6 +14,7 @@ import com.getcapacitor.JSObject;
 import com.getcapacitor.MessageHandler;
 import com.getcapacitor.PluginCall;
 import com.getcapacitor.PluginResult;
+import com.google.common.util.concurrent.Futures;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -117,23 +118,27 @@ public class NativeAudioPlayerPluginTest {
         assertResolved(seekCall);
     }
 
+    /**
+     * These three promise {id: string}, so without an item there is nothing to
+     * resolve with -- they still have to answer instead of leaving JS waiting.
+     */
     @Test
-    public void testNavigationMethodsResolveWithoutAController() throws Exception {
+    public void testNavigationMethodsRejectWithoutAController() {
         PluginCall nextCall = call();
         plugin.next(nextCall);
-        assertResolved(nextCall);
+        assertRejected(nextCall);
 
         setUp();
         PluginCall previousCall = call();
         plugin.previous(previousCall);
-        assertResolved(previousCall);
+        assertRejected(previousCall);
 
         setUp();
         JSObject data = new JSObject();
         data.put("id", "item1");
         PluginCall selectCall = call(data);
         plugin.select(selectCall);
-        assertResolved(selectCall);
+        assertRejected(selectCall);
     }
 
     @Test
@@ -265,6 +270,48 @@ public class NativeAudioPlayerPluginTest {
 
     // Java assertions are disabled at runtime on Android, so the assert this
     // replaces never guarded anything.
+
+    // A start() that fails after the controller connected has to leave nothing
+    // behind: the controller keeps its listener and its session connection alive.
+
+    @Test
+    public void testAttachControllerConfiguresTheControllerAndResolvesWithTheFirstId() throws Exception {
+        MediaController controller = controllerWithCurrentItem("item1");
+        plugin.mediaItems = new java.util.ArrayList<>();
+        PluginCall call = call();
+
+        plugin.attachController(Futures.immediateFuture(controller), call);
+
+        verify(controller).setMediaItems(plugin.mediaItems);
+        verify(controller).addListener(plugin.playerListener);
+        Assert.assertEquals("item1", assertResolved(call).getString("id"));
+    }
+
+    @Test
+    public void testAttachControllerReleasesTheControllerWhenSetupFails() {
+        MediaController controller = mock(MediaController.class);
+        doThrow(new IllegalStateException("boom")).when(controller).setMediaItems(org.mockito.ArgumentMatchers.any());
+        plugin.mediaItems = new java.util.ArrayList<>();
+        PluginCall call = call();
+
+        plugin.attachController(Futures.immediateFuture(controller), call);
+
+        verify(controller).release();
+        Assert.assertNull(plugin.mediaController);
+        Assert.assertNull(plugin.mediaItems);
+        assertRejected(call);
+    }
+
+    @Test
+    public void testAttachControllerRejectsWhenTheConnectionFails() {
+        plugin.mediaItems = new java.util.ArrayList<>();
+        PluginCall call = call();
+
+        plugin.attachController(Futures.immediateFailedFuture(new IllegalStateException("no session")), call);
+
+        Assert.assertNull(plugin.mediaController);
+        assertRejected(call);
+    }
 
     @Test
     public void testMediaItemTransitionToleratesANullItem() {

--- a/android/src/test/java/app/smartcompanion/audio/NativeAudioPlayerPluginTest.java
+++ b/android/src/test/java/app/smartcompanion/audio/NativeAudioPlayerPluginTest.java
@@ -1,0 +1,280 @@
+package app.smartcompanion.audio;
+
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import androidx.media3.common.MediaItem;
+import androidx.media3.session.MediaController;
+import com.getcapacitor.JSObject;
+import com.getcapacitor.MessageHandler;
+import com.getcapacitor.PluginCall;
+import com.getcapacitor.PluginResult;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InOrder;
+import org.robolectric.RobolectricTestRunner;
+
+/**
+ * Drives the plugin without a Bridge. Plugin#notifyListeners and PluginCall
+ * resolve/reject only touch state the plugin owns, so a mocked MessageHandler
+ * is enough to observe how a call was answered.
+ */
+@RunWith(RobolectricTestRunner.class)
+public class NativeAudioPlayerPluginTest {
+
+    private NativeAudioPlayerPlugin plugin;
+    private MessageHandler messageHandler;
+
+    @Before
+    public void setUp() {
+        plugin = new NativeAudioPlayerPlugin();
+        messageHandler = mock(MessageHandler.class);
+    }
+
+    private PluginCall call() {
+        return call(new JSObject());
+    }
+
+    private PluginCall call(JSObject data) {
+        return new PluginCall(messageHandler, "NativeAudioPlayer", "callback-id", "method", data);
+    }
+
+    private MediaController controllerWithCurrentItem(String id) {
+        MediaController controller = mock(MediaController.class);
+        when(controller.getCurrentMediaItem()).thenReturn(new MediaItem.Builder().setMediaId(id).build());
+        return controller;
+    }
+
+    /**
+     * Fails when a code path never resolves or rejects, which hangs the promise in
+     * JS. Returns the resolved payload -- PluginResult holds it directly, the
+     * {pluginId, data, ...} envelope is added later by MessageHandler.
+     */
+    private JSObject assertResolved(PluginCall call) throws Exception {
+        ArgumentCaptor<PluginResult> success = ArgumentCaptor.forClass(PluginResult.class);
+        ArgumentCaptor<PluginResult> error = ArgumentCaptor.forClass(PluginResult.class);
+
+        verify(messageHandler).sendResponseMessage(eq(call), success.capture(), error.capture());
+
+        Assert.assertNull("expected the call to resolve, but it rejected", error.getValue());
+
+        PluginResult result = success.getValue();
+        return result == null ? new JSObject() : new JSObject(result.toString());
+    }
+
+    private void assertRejected(PluginCall call) {
+        ArgumentCaptor<PluginResult> success = ArgumentCaptor.forClass(PluginResult.class);
+        ArgumentCaptor<PluginResult> error = ArgumentCaptor.forClass(PluginResult.class);
+
+        verify(messageHandler).sendResponseMessage(eq(call), success.capture(), error.capture());
+
+        Assert.assertNotNull("expected the call to reject", error.getValue());
+    }
+
+    // Without a controller every method has to answer its call rather than throw.
+
+    @Test
+    public void testGetPositionReportsZeroWithoutAController() throws Exception {
+        PluginCall call = call();
+
+        plugin.getPosition(call);
+
+        // an absent key reaches JS as undefined, where iOS and web both report 0
+        Assert.assertEquals(0L, assertResolved(call).getLong("value"));
+    }
+
+    @Test
+    public void testGetDurationReportsZeroWithoutAController() throws Exception {
+        PluginCall call = call();
+
+        plugin.getDuration(call);
+
+        Assert.assertEquals(0L, assertResolved(call).getLong("value"));
+    }
+
+    @Test
+    public void testPlaybackMethodsResolveWithoutAController() throws Exception {
+        PluginCall playCall = call();
+        plugin.play(playCall);
+        assertResolved(playCall);
+
+        setUp();
+        PluginCall pauseCall = call();
+        plugin.pause(pauseCall);
+        assertResolved(pauseCall);
+
+        setUp();
+        PluginCall seekCall = call();
+        plugin.seekTo(seekCall);
+        assertResolved(seekCall);
+    }
+
+    @Test
+    public void testNavigationMethodsResolveWithoutAController() throws Exception {
+        PluginCall nextCall = call();
+        plugin.next(nextCall);
+        assertResolved(nextCall);
+
+        setUp();
+        PluginCall previousCall = call();
+        plugin.previous(previousCall);
+        assertResolved(previousCall);
+
+        setUp();
+        JSObject data = new JSObject();
+        data.put("id", "item1");
+        PluginCall selectCall = call(data);
+        plugin.select(selectCall);
+        assertResolved(selectCall);
+    }
+
+    @Test
+    public void testStopResolvesWithoutAController() throws Exception {
+        PluginCall call = call();
+
+        plugin.stop(call);
+
+        assertResolved(call);
+    }
+
+    @Test
+    public void testStopToleratesANullCall() {
+        // handleOnDestroy() calls stop(null)
+        plugin.stop(null);
+
+        verify(messageHandler, never()).sendResponseMessage(
+            org.mockito.ArgumentMatchers.any(),
+            org.mockito.ArgumentMatchers.any(),
+            org.mockito.ArgumentMatchers.any()
+        );
+    }
+
+    // stop() used to null the field before calling unregisterPlayerEvents(),
+    // whose own null guard then short circuited, so the listener stayed attached.
+
+    @Test
+    public void testStopRemovesTheListenerBeforeReleasingTheController() throws Exception {
+        MediaController controller = mock(MediaController.class);
+        plugin.mediaController = controller;
+
+        plugin.stop(call());
+
+        InOrder inOrder = inOrder(controller);
+        inOrder.verify(controller).removeListener(plugin.playerListener);
+        inOrder.verify(controller).release();
+        Assert.assertNull(plugin.mediaController);
+    }
+
+    @Test
+    public void testStopClearsTheMediaItems() throws Exception {
+        plugin.mediaItems = new java.util.ArrayList<>();
+
+        plugin.stop(call());
+
+        Assert.assertNull(plugin.mediaItems);
+    }
+
+    @Test
+    public void testStopAnswersTheCallWhenTheControllerThrows() {
+        MediaController controller = mock(MediaController.class);
+        doThrow(new IllegalStateException("boom")).when(controller).pause();
+        plugin.mediaController = controller;
+        PluginCall call = call();
+
+        plugin.stop(call);
+
+        // the exception used to be logged and swallowed, leaving the promise pending
+        assertRejected(call);
+        Assert.assertNull(plugin.mediaController);
+    }
+
+    // The TypeScript definitions promise {id: string} from these three.
+
+    @Test
+    public void testNextResolvesWithTheCurrentItemId() throws Exception {
+        plugin.mediaController = controllerWithCurrentItem("item2");
+        PluginCall call = call();
+
+        plugin.next(call);
+
+        Assert.assertEquals("item2", assertResolved(call).getString("id"));
+    }
+
+    @Test
+    public void testPreviousResolvesWithTheCurrentItemId() throws Exception {
+        plugin.mediaController = controllerWithCurrentItem("item1");
+        PluginCall call = call();
+
+        plugin.previous(call);
+
+        Assert.assertEquals("item1", assertResolved(call).getString("id"));
+    }
+
+    @Test
+    public void testSelectSeeksToTheMatchingItemAndResolvesWithItsId() throws Exception {
+        MediaController controller = controllerWithCurrentItem("item2");
+        when(controller.getMediaItemCount()).thenReturn(2);
+        when(controller.getMediaItemAt(0)).thenReturn(new MediaItem.Builder().setMediaId("item1").build());
+        when(controller.getMediaItemAt(1)).thenReturn(new MediaItem.Builder().setMediaId("item2").build());
+        plugin.mediaController = controller;
+
+        JSObject data = new JSObject();
+        data.put("id", "item2");
+        PluginCall call = call(data);
+
+        plugin.select(call);
+
+        verify(controller).seekTo(1, 0);
+        Assert.assertEquals("item2", assertResolved(call).getString("id"));
+    }
+
+    // A second start() used to leave the previous listener attached, so every
+    // update event was delivered twice.
+
+    @Test
+    public void testRegisterPlayerEventsRemovesBeforeAdding() {
+        MediaController controller = mock(MediaController.class);
+        plugin.mediaController = controller;
+
+        plugin.registerPlayerEvents();
+
+        InOrder inOrder = inOrder(controller);
+        inOrder.verify(controller).removeListener(plugin.playerListener);
+        inOrder.verify(controller).addListener(plugin.playerListener);
+    }
+
+    @Test
+    public void testReleaseControllerUnregistersAndClearsTheController() {
+        MediaController controller = mock(MediaController.class);
+        plugin.mediaController = controller;
+
+        plugin.releaseController();
+
+        verify(controller).removeListener(plugin.playerListener);
+        verify(controller).release();
+        Assert.assertNull(plugin.mediaController);
+    }
+
+    // Java assertions are disabled at runtime on Android, so the assert this
+    // replaces never guarded anything.
+
+    @Test
+    public void testMediaItemTransitionToleratesANullItem() {
+        plugin.mediaController = mock(MediaController.class);
+
+        plugin.playerListener.onMediaItemTransition(null, androidx.media3.common.Player.MEDIA_ITEM_TRANSITION_REASON_SEEK);
+    }
+
+    @Test
+    public void testMediaItemTransitionToleratesAMissingController() {
+        plugin.playerListener.onMediaItemTransition(null, androidx.media3.common.Player.MEDIA_ITEM_TRANSITION_REASON_AUTO);
+    }
+}

--- a/android/src/test/java/app/smartcompanion/audio/NativeAudioPlayerTest.java
+++ b/android/src/test/java/app/smartcompanion/audio/NativeAudioPlayerTest.java
@@ -54,4 +54,51 @@ public class NativeAudioPlayerTest {
         Assert.assertEquals("item2", items.get(1).mediaId);
         Assert.assertEquals("title item2", items.get(1).mediaMetadata.title);
     }
+
+    @Test
+    public void testShouldMapSubtitleToBothSubtitleAndArtist() throws Exception {
+        List<MediaItem> items = nativeAudioPlayer.fromJson(getItems());
+
+        Assert.assertEquals("subtitle item1", items.get(0).mediaMetadata.subtitle);
+        Assert.assertEquals("subtitle item1", items.get(0).mediaMetadata.artist);
+        Assert.assertEquals("http://something.com/image1.jpg", items.get(0).mediaMetadata.artworkUri.toString());
+    }
+
+    @Test
+    public void testShouldReturnAnEmptyListForMalformedJson() throws Exception {
+        JSONObject jsObject = new JSONObject();
+        jsObject.put("items", "not an array");
+
+        // an exception without a message used to escape the catch block here,
+        // because it logged Objects.requireNonNull(e.getMessage())
+        List<MediaItem> items = nativeAudioPlayer.fromJson(JSObject.fromJSONObject(jsObject));
+
+        Assert.assertTrue(items.isEmpty());
+    }
+
+    @Test
+    public void testShouldReturnAnEmptyListWhenItemsAreMissing() throws Exception {
+        List<MediaItem> items = nativeAudioPlayer.fromJson(new JSObject());
+
+        Assert.assertTrue(items.isEmpty());
+    }
+
+    @Test
+    public void testShouldPrepareAnUpdateEvent() throws Exception {
+        MediaItem mediaItem = new MediaItem.Builder().setMediaId("item1").build();
+
+        JSObject json = nativeAudioPlayer.prepareUpdateEvent("playing", mediaItem);
+
+        Assert.assertEquals("playing", json.getString("state"));
+        Assert.assertEquals("item1", json.getString("id"));
+    }
+
+    @Test
+    public void testShouldPrepareAnIdItem() throws Exception {
+        MediaItem mediaItem = new MediaItem.Builder().setMediaId("item1").build();
+
+        JSObject json = nativeAudioPlayer.prepareIdItem(mediaItem);
+
+        Assert.assertEquals("item1", json.getString("id"));
+    }
 }

--- a/ios/Sources/NativeAudioPlayerPlugin/NativeAudioPlayer.swift
+++ b/ios/Sources/NativeAudioPlayerPlugin/NativeAudioPlayer.swift
@@ -1,41 +1,37 @@
 import Foundation
 import AVFoundation
-import Capacitor
 import MediaPlayer
+import UIKit
 
 @objc public class NativeAudioPlayer: NSObject, AVAudioPlayerDelegate {
-    
+
     var playerItems: [AudioPlayerItem] = []
     var audioPlayer: AVAudioPlayer?
     var currentIndex: Int = 0
     var earpiece: Bool = true
+
+    // the item currentIndex points at, or nil while the playlist is empty --
+    // everything below reads through this so an unset playlist cannot trap
+    var currentItem: AudioPlayerItem? {
+        playerItems.indices.contains(currentIndex) ? playerItems[currentIndex] : nil
+    }
     var currentId: String {
-        get {
-            return playerItems[currentIndex].id
-        }
+        currentItem?.id ?? ""
     }
     var duration: Int {
-        get {
-            return Int(audioPlayer?.duration ?? 0)
-        }
+        Int(audioPlayer?.duration ?? 0)
     }
     var position: Int {
-        get {
-            return Int(audioPlayer?.currentTime ?? 0)
-        }
+        Int(audioPlayer?.currentTime ?? 0)
     }
     var title: String {
-        get {
-            return playerItems[currentIndex].title
-        }
+        currentItem?.title ?? ""
     }
     var subtitle: String {
-        get {
-            return playerItems[currentIndex].subtitle
-        }
+        currentItem?.subtitle ?? ""
     }
     var onCompleted: ((_ id: String) -> Void)?
-                
+
     init(_ items: [[String: Any]]) {
         for item in items {
             let playerItem = AudioPlayerItem()
@@ -47,14 +43,43 @@ import MediaPlayer
             playerItems.append(playerItem)
         }
     }
-    
+
+    deinit {
+        // only tear down when this instance still owns a player: an instance that
+        // never loaded must not deactivate the session or clear the lock screen
+        // that a different instance has since taken over
+        if audioPlayer != nil {
+            stop()
+        }
+    }
+
+    // Capacitor's Filesystem API hands back fully qualified file:// URLs, but a
+    // plain path is just as valid -- accept both instead of rebuilding the path
+    // from its last component, which only ever resolved for Directory.Data.
+    private func resolveURL(_ uri: String) -> URL? {
+        guard !uri.isEmpty else {
+            return nil
+        }
+
+        if let url = URL(string: uri), url.scheme != nil {
+            return url
+        }
+
+        return URL(fileURLWithPath: uri)
+    }
+
+    @discardableResult
     func load() -> Bool {
+        guard let item = currentItem, let url = resolveURL(item.audioUri) else {
+            return false
+        }
+
         do {
-            let audioSession : AVAudioSession = AVAudioSession.sharedInstance()
-            
+            let audioSession: AVAudioSession = AVAudioSession.sharedInstance()
+
             // only when setting .playAndRecord an output to earpiece is possible
             try audioSession.setCategory(.playAndRecord, mode: .default, options: [.allowAirPlay, .allowBluetoothA2DP])
-                                    
+
             // only try to override earpiece/speaker if selected output port
             // is builtInSpeaker/Receiver otherwise do nothing, e.g., in the case of airpods
             let portType = audioSession.currentRoute.outputs.first?.portType
@@ -63,27 +88,17 @@ import MediaPlayer
                     earpiece ? AVAudioSession.PortOverride.none : AVAudioSession.PortOverride.speaker
                 )
             }
-            
+
             // set active as last
             try audioSession.setActive(true, options: .notifyOthersOnDeactivation)
-                                    
-            //audioSession.currentRoute.outputs.forEach { print($0) }
-                        
-            if audioPlayer != nil {
-                audioPlayer?.stop()
-                audioPlayer = nil
-            }
-            
-            let url = URL(fileURLWithPath: playerItems[currentIndex].audioUri)
-            guard let dir = FileManager.default.urls(for: FileManager.SearchPathDirectory.documentDirectory, in: .userDomainMask).first else {
-                return false
-            }
-            audioPlayer = try AVAudioPlayer(contentsOf: dir.appendingPathComponent(url.lastPathComponent))
+
+            audioPlayer?.stop()
+            audioPlayer = try AVAudioPlayer(contentsOf: url)
             audioPlayer?.prepareToPlay()
             audioPlayer?.delegate = self
-            
+
             initLockScreen()
-            
+
             return true
         } catch {
             if !earpiece {
@@ -91,82 +106,82 @@ import MediaPlayer
                 return self.load()
             }
         }
-        
+
         return false
     }
-    
+
     func stop() {
-        if audioPlayer != nil {
-            audioPlayer?.stop()
-            audioPlayer = nil
-        }
-        
+        audioPlayer?.stop()
+        audioPlayer = nil
+
         // remove player from lock screen
         try? AVAudioSession.sharedInstance().setActive(false, options: .notifyOthersOnDeactivation)
         MPNowPlayingInfoCenter.default().nowPlayingInfo = nil
     }
-    
+
     func play() {
-        if let playing = audioPlayer?.isPlaying {
-            if !playing {
-                audioPlayer?.play()
-                initLockScreen(self.position)
-            }
+        if audioPlayer?.isPlaying == false {
+            audioPlayer?.play()
+            initLockScreen(self.position)
         }
     }
-    
+
     func pause() {
-        if let playing = audioPlayer?.isPlaying {
-            if playing {
-                audioPlayer?.pause()
-            }
+        if audioPlayer?.isPlaying == true {
+            audioPlayer?.pause()
         }
     }
-    
+
     func select(_ id: String) -> Bool {
-        pause()
-        
-        for index in playerItems.indices {
-            if playerItems[index].id == id {
-                currentIndex = index
-                break
-            }
+        guard !playerItems.isEmpty else {
+            return false
         }
-        
+
+        pause()
+
+        if let index = playerItems.firstIndex(where: { $0.id == id }) {
+            currentIndex = index
+        }
+
         return load()
     }
-    
+
     func next() -> Bool {
+        guard !playerItems.isEmpty else {
+            return false
+        }
+
         pause()
-        
+
         if currentIndex < (playerItems.count - 1) {
             currentIndex += 1
         } else {
             currentIndex = 0
         }
-        
+
         return load()
     }
-    
+
     func previous() -> Bool {
+        guard !playerItems.isEmpty else {
+            return false
+        }
+
         pause()
-        
+
         if currentIndex > 0 {
             currentIndex -= 1
         } else {
             currentIndex = playerItems.count - 1
         }
-        
+
         return load()
     }
-    
+
     func seekTo(_ position: Int) {
-        if audioPlayer != nil {
-            //pause()
-            audioPlayer?.currentTime = Double(position)
-        }
+        audioPlayer?.currentTime = Double(position)
     }
-    
+
     func setEarpiece() {
         let oldPosition = position
         pause()
@@ -174,7 +189,7 @@ import MediaPlayer
         load()
         seekTo(oldPosition)
     }
-    
+
     func setSpeaker() {
         let oldPosition = position
         pause()
@@ -182,31 +197,33 @@ import MediaPlayer
         load()
         seekTo(oldPosition)
     }
-    
+
     func initLockScreen(_ position: Int = 0) {
-        guard let dir = FileManager.default.urls(for: FileManager.SearchPathDirectory.documentDirectory, in: .userDomainMask).first else {
+        guard let item = currentItem else {
             return
         }
-        
-        let url = URL(fileURLWithPath: self.playerItems[self.currentIndex].imageUri)
-        
-        MPNowPlayingInfoCenter.default().nowPlayingInfo = [
+
+        var nowPlayingInfo: [String: Any] = [
             MPMediaItemPropertyTitle: self.title,
             MPMediaItemPropertyArtist: self.subtitle,
             MPMediaItemPropertyPlaybackDuration: self.duration,
-            MPMediaItemPropertyArtwork: MPMediaItemArtwork(boundsSize: CGSize(width: 500, height: 500), requestHandler: { (size) -> UIImage in
-                let uri = dir.appendingPathComponent(url.lastPathComponent).path
-                return UIImage(contentsOfFile: uri)!
-            }),
             MPNowPlayingInfoPropertyPlaybackRate: 1.0,
             MPNowPlayingInfoPropertyElapsedPlaybackTime: position
         ]
+
+        // decode up front: the artwork request handler is invoked by the system on
+        // an arbitrary thread, where a missing or corrupt image used to crash
+        if let imageURL = resolveURL(item.imageUri), let image = UIImage(contentsOfFile: imageURL.path) {
+            nowPlayingInfo[MPMediaItemPropertyArtwork] = MPMediaItemArtwork(boundsSize: image.size) { _ in image }
+        }
+
+        MPNowPlayingInfoCenter.default().nowPlayingInfo = nowPlayingInfo
     }
-    
+
     public func audioPlayerDidFinishPlaying(_ player: AVAudioPlayer, successfully flag: Bool) {
-        if (flag) {            
+        if flag {
             onCompleted?(self.currentId)
         }
     }
-    
+
 }

--- a/ios/Sources/NativeAudioPlayerPlugin/NativeAudioPlayerPlugin.swift
+++ b/ios/Sources/NativeAudioPlayerPlugin/NativeAudioPlayerPlugin.swift
@@ -24,11 +24,13 @@ public class NativeAudioPlayerPlugin: CAPPlugin, CAPBridgedPlugin {
 
     private var player: NativeAudioPlayer = NativeAudioPlayer([])
 
-    private var pauseTarget: Any?
-    private var playTarget: Any?
-    private var nextTarget: Any?
-    private var previousTarget: Any?
-    private var seekTarget: Any?
+    // not private so the tests can tell an installed target from a removed one --
+    // MPRemoteCommand exposes no way to read back what is registered on it
+    var pauseTarget: Any?
+    var playTarget: Any?
+    var nextTarget: Any?
+    var previousTarget: Any?
+    var seekTarget: Any?
 
     deinit {
         // MPRemoteCommandCenter is a process-wide singleton and holds its target
@@ -78,6 +80,9 @@ public class NativeAudioPlayerPlugin: CAPPlugin, CAPBridgedPlugin {
                 "id": player.currentId
             ])
         } else {
+            // the player this start() replaced is gone, so its handlers must not stay
+            // on the process-wide command center and drive a player nobody can reach
+            removeRemoteCommandTargets()
             call.reject("could not load audio items")
         }
     }

--- a/ios/Sources/NativeAudioPlayerPlugin/NativeAudioPlayerPlugin.swift
+++ b/ios/Sources/NativeAudioPlayerPlugin/NativeAudioPlayerPlugin.swift
@@ -8,10 +8,10 @@ public class NativeAudioPlayerPlugin: CAPPlugin, CAPBridgedPlugin {
     public let jsName = "NativeAudioPlayer"
 
     public let pluginMethods: [CAPPluginMethod] = [
-        CAPPluginMethod(name: "start", returnType: CAPPluginReturnPromise),        
+        CAPPluginMethod(name: "start", returnType: CAPPluginReturnPromise),
         CAPPluginMethod(name: "play", returnType: CAPPluginReturnPromise),
         CAPPluginMethod(name: "pause", returnType: CAPPluginReturnPromise),
-        CAPPluginMethod(name: "select", returnType: CAPPluginReturnPromise),        
+        CAPPluginMethod(name: "select", returnType: CAPPluginReturnPromise),
         CAPPluginMethod(name: "next", returnType: CAPPluginReturnPromise),
         CAPPluginMethod(name: "previous", returnType: CAPPluginReturnPromise),
         CAPPluginMethod(name: "stop", returnType: CAPPluginReturnPromise),
@@ -23,59 +23,57 @@ public class NativeAudioPlayerPlugin: CAPPlugin, CAPBridgedPlugin {
     ]
 
     private var player: NativeAudioPlayer = NativeAudioPlayer([])
-    
+
     private var pauseTarget: Any?
     private var playTarget: Any?
     private var nextTarget: Any?
     private var previousTarget: Any?
     private var seekTarget: Any?
-        
+
+    deinit {
+        // MPRemoteCommandCenter is a process-wide singleton and holds its target
+        // blocks for the lifetime of the app -- leaving them behind leaks the plugin
+        removeRemoteCommandTargets()
+    }
+
     @objc func start(_ call: CAPPluginCall) {
         let items = call.getArray("items", [String: Any].self) ?? []
         player = NativeAudioPlayer(items)
-        player.onCompleted = self.onCompleted
-        
+        player.onCompleted = { [weak self] id in
+            self?.onCompleted(id)
+        }
+
         if player.load() {
             let commandCenter = MPRemoteCommandCenter.shared()
-                
-            commandCenter.pauseCommand.isEnabled = true
-            commandCenter.pauseCommand.removeTarget(pauseTarget)
-            pauseTarget = commandCenter.pauseCommand.addTarget { event in
-                self.onPause()
+
+            setTarget(commandCenter.pauseCommand, &pauseTarget) { [weak self] _ in
+                self?.onPause()
                 return .success
             }
-            
-            commandCenter.playCommand.isEnabled = true
-            commandCenter.playCommand.removeTarget(playTarget)
-            playTarget = commandCenter.playCommand.addTarget { event in
-                self.onPlay()
+
+            setTarget(commandCenter.playCommand, &playTarget) { [weak self] _ in
+                self?.onPlay()
                 return .success
             }
-                        
-            commandCenter.nextTrackCommand.isEnabled = true
-            commandCenter.nextTrackCommand.removeTarget(nextTarget)
-            nextTarget = commandCenter.nextTrackCommand.addTarget { event in
-                self.onNext()
+
+            setTarget(commandCenter.nextTrackCommand, &nextTarget) { [weak self] _ in
+                _ = self?.onNext()
                 return .success
             }
-            
-            commandCenter.previousTrackCommand.isEnabled = true
-            commandCenter.previousTrackCommand.removeTarget(previousTarget)
-            previousTarget = commandCenter.previousTrackCommand.addTarget { event in
-                self.onPrevious()
+
+            setTarget(commandCenter.previousTrackCommand, &previousTarget) { [weak self] _ in
+                _ = self?.onPrevious()
                 return .success
             }
-            
-            commandCenter.changePlaybackPositionCommand.isEnabled = true
-            commandCenter.changePlaybackPositionCommand.removeTarget(seekTarget)
-            seekTarget = commandCenter.changePlaybackPositionCommand.addTarget { event in
+
+            setTarget(commandCenter.changePlaybackPositionCommand, &seekTarget) { [weak self] event in
                 if let changePlaybackPositionCommandEvent = event as? MPChangePlaybackPositionCommandEvent {
                     let positionTime = changePlaybackPositionCommandEvent.positionTime
-                    self.player.seekTo(Int(positionTime))
+                    self?.player.seekTo(Int(positionTime))
                 }
                 return .success
             }
-                                                
+
             call.resolve([
                 "id": player.currentId
             ])
@@ -83,26 +81,27 @@ public class NativeAudioPlayerPlugin: CAPPlugin, CAPBridgedPlugin {
             call.reject("could not load audio items")
         }
     }
-    
+
     @objc func stop(_ call: CAPPluginCall) {
         onPause()
         player.stop()
+        removeRemoteCommandTargets()
         call.resolve()
     }
-    
+
     @objc func play(_ call: CAPPluginCall) {
         onPlay()
         call.resolve()
     }
-    
+
     @objc func pause(_ call: CAPPluginCall) {
         onPause()
         call.resolve()
     }
-    
+
     @objc func select(_ call: CAPPluginCall) {
         let id = call.getString("id") ?? ""
-        
+
         if player.select(id) {
             self.notifyListeners("update", data: ["id": player.currentId, "state": "skip"])
             call.resolve(["id": player.currentId])
@@ -110,7 +109,7 @@ public class NativeAudioPlayerPlugin: CAPPlugin, CAPBridgedPlugin {
             call.reject("could not switch to item with given id")
         }
     }
-    
+
     @objc func next(_ call: CAPPluginCall) {
         if onNext() {
             call.resolve(["id": player.currentId])
@@ -118,7 +117,7 @@ public class NativeAudioPlayerPlugin: CAPPlugin, CAPBridgedPlugin {
             call.reject("could not switch to next item")
         }
     }
-    
+
     @objc func previous(_ call: CAPPluginCall) {
         if onPrevious() {
             call.resolve(["id": player.currentId])
@@ -126,45 +125,82 @@ public class NativeAudioPlayerPlugin: CAPPlugin, CAPBridgedPlugin {
             call.reject("could not switch to previous item")
         }
     }
-            
+
     @objc func seekTo(_ call: CAPPluginCall) {
         let position = call.getInt("position") ?? 0
-        //self.notifyListeners("update", data: ["id": player.currentId, "state": "paused"])
         player.seekTo(position)
         call.resolve()
     }
-    
+
     @objc func getPosition(_ call: CAPPluginCall) {
         call.resolve(["value": player.position])
     }
-    
+
     @objc func getDuration(_ call: CAPPluginCall) {
         call.resolve(["value": player.duration])
     }
-    
+
     @objc func setEarpiece(_ call: CAPPluginCall) {
         self.notifyListeners("update", data: ["id": player.currentId, "state": "paused"])
         player.setEarpiece()
         call.resolve()
     }
-        
+
     @objc func setSpeaker(_ call: CAPPluginCall) {
         self.notifyListeners("update", data: ["id": player.currentId, "state": "paused"])
         player.setSpeaker()
         call.resolve()
     }
-    
+
+    private func setTarget(
+        _ command: MPRemoteCommand,
+        _ existing: inout Any?,
+        handler: @escaping (MPRemoteCommandEvent) -> MPRemoteCommandHandlerStatus
+    ) {
+        command.isEnabled = true
+
+        // removeTarget(nil) drops *every* target registered for the command,
+        // including ones belonging to the host app or another plugin
+        if let existing {
+            command.removeTarget(existing)
+        }
+
+        existing = command.addTarget(handler: handler)
+    }
+
+    private func removeRemoteCommandTargets() {
+        let commandCenter = MPRemoteCommandCenter.shared()
+        let registered: [(MPRemoteCommand, Any?)] = [
+            (commandCenter.pauseCommand, pauseTarget),
+            (commandCenter.playCommand, playTarget),
+            (commandCenter.nextTrackCommand, nextTarget),
+            (commandCenter.previousTrackCommand, previousTarget),
+            (commandCenter.changePlaybackPositionCommand, seekTarget)
+        ]
+
+        for (command, target) in registered {
+            if let target {
+                command.removeTarget(target)
+            }
+        }
+
+        pauseTarget = nil
+        playTarget = nil
+        nextTarget = nil
+        previousTarget = nil
+        seekTarget = nil
+    }
+
     private func onPlay() {
         player.play()
         self.notifyListeners("update", data: ["id": player.currentId, "state": "playing"])
     }
-    
+
     private func onPause() {
-        
         player.pause()
         self.notifyListeners("update", data: ["id": player.currentId, "state": "paused"])
     }
-    
+
     private func onNext() -> Bool {
         if player.next() {
             self.notifyListeners("update", data: ["id": player.currentId, "state": "skip"])
@@ -173,7 +209,7 @@ public class NativeAudioPlayerPlugin: CAPPlugin, CAPBridgedPlugin {
             return false
         }
     }
-    
+
     private func onPrevious() -> Bool {
         if player.previous() {
             self.notifyListeners("update", data: ["id": player.currentId, "state": "skip"])
@@ -182,9 +218,9 @@ public class NativeAudioPlayerPlugin: CAPPlugin, CAPBridgedPlugin {
             return false
         }
     }
-    
+
     private func onCompleted(_ id: String) {
         self.notifyListeners("update", data: ["id": id, "state": "completed"])
     }
-    
+
 }

--- a/ios/Tests/NativeAudioPlayerPluginTests/NativeAudioPlayerPluginTests.swift
+++ b/ios/Tests/NativeAudioPlayerPluginTests/NativeAudioPlayerPluginTests.swift
@@ -1,0 +1,338 @@
+import XCTest
+import Capacitor
+import MediaPlayer
+import UIKit
+@testable import NativeAudioPlayerPlugin
+
+/// Captures the `update` events the plugin emits. Overriding `notifyListeners`
+/// keeps these tests free of a `CapacitorBridge`, which cannot be built headless.
+private class RecordingPlugin: NativeAudioPlayerPlugin {
+    private(set) var events: [(name: String, data: [String: Any])] = []
+
+    override func notifyListeners(_ eventName: String, data: [String: Any]?) {
+        events.append((eventName, data ?? [:]))
+    }
+
+    var states: [String] {
+        events.compactMap { $0.data["state"] as? String }
+    }
+}
+
+/// Records how a call was answered. `answered` stays false if a code path
+/// forgets to resolve or reject, which would hang the promise in JS.
+private class CallRecorder {
+    private(set) var resolved: [String: Any]?
+    private(set) var rejected: String?
+    private(set) var answered = false
+
+    func makeCall(_ options: [String: Any] = [:]) -> CAPPluginCall {
+        // coerced the same way CapacitorBridge does before invoking a plugin, so
+        // the typed accessors in the plugin see the shape they see in production
+        let coerced = JSTypes.coerceDictionaryToJSObject(options as NSDictionary, formattingDatesAsStrings: true) ?? [:]
+
+        return CAPPluginCall(
+            callbackId: "test",
+            methodName: "test",
+            options: coerced,
+            success: { [weak self] result, _ in
+                self?.answered = true
+                self?.resolved = result?.data ?? [:]
+            },
+            error: { [weak self] error in
+                self?.answered = true
+                self?.rejected = error?.message
+            }
+        )
+    }
+}
+
+class NativeAudioPlayerPluginTests: XCTestCase {
+
+    private var sandbox = FileManager.default.temporaryDirectory
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        sandbox = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        try FileManager.default.createDirectory(at: sandbox, withIntermediateDirectories: true)
+    }
+
+    override func tearDownWithError() throws {
+        try? FileManager.default.removeItem(at: sandbox)
+        MPNowPlayingInfoCenter.default().nowPlayingInfo = nil
+        try super.tearDownWithError()
+    }
+
+    // MARK: - Fixtures
+
+    /// A silent 16-bit mono WAV. Written at runtime so the repo stays free of
+    /// binary assets, and just enough of a file for AVAudioPlayer to open it.
+    private func writeAudioFile(at relativePath: String) throws -> URL {
+        let sampleRate = 8000
+        let frames = sampleRate / 10
+        let dataSize = frames * 2
+
+        var data = Data()
+        func append(_ text: String) { data.append(contentsOf: Array(text.utf8)) }
+        func append(uint32 value: UInt32) { withUnsafeBytes(of: value.littleEndian) { data.append(contentsOf: $0) } }
+        func append(uint16 value: UInt16) { withUnsafeBytes(of: value.littleEndian) { data.append(contentsOf: $0) } }
+
+        append("RIFF")
+        append(uint32: UInt32(36 + dataSize))
+        append("WAVE")
+        append("fmt ")
+        append(uint32: 16)
+        append(uint16: 1)
+        append(uint16: 1)
+        append(uint32: UInt32(sampleRate))
+        append(uint32: UInt32(sampleRate * 2))
+        append(uint16: 2)
+        append(uint16: 16)
+        append("data")
+        append(uint32: UInt32(dataSize))
+        data.append(Data(count: dataSize))
+
+        let url = sandbox.appendingPathComponent(relativePath)
+        try FileManager.default.createDirectory(at: url.deletingLastPathComponent(), withIntermediateDirectories: true)
+        try data.write(to: url)
+        return url
+    }
+
+    private func writeImageFile(at relativePath: String) throws -> URL {
+        let renderer = UIGraphicsImageRenderer(size: CGSize(width: 4, height: 4))
+        let data = renderer.image { context in
+            UIColor.red.setFill()
+            context.fill(CGRect(x: 0, y: 0, width: 4, height: 4))
+        }.pngData()
+
+        let url = sandbox.appendingPathComponent(relativePath)
+        try FileManager.default.createDirectory(at: url.deletingLastPathComponent(), withIntermediateDirectories: true)
+        try XCTUnwrap(data).write(to: url)
+        return url
+    }
+
+    private func item(id: String, audio: URL, image: URL? = nil) -> [String: Any] {
+        return [
+            "id": id,
+            "title": "Title \(id)",
+            "subtitle": "Subtitle \(id)",
+            "audioUri": audio.absoluteString,
+            "imageUri": image?.absoluteString ?? "\(sandbox.absoluteString)missing-\(id).jpg"
+        ]
+    }
+
+    // MARK: - Calls before start()
+    //
+    // Every one of these used to trap on playerItems[currentIndex], because the
+    // plugin starts out holding a NativeAudioPlayer over an empty item list.
+
+    func testStopBeforeStartResolvesAndReportsAnEmptyId() {
+        let plugin = RecordingPlugin()
+        let recorder = CallRecorder()
+
+        plugin.stop(recorder.makeCall())
+
+        XCTAssertTrue(recorder.answered)
+        XCTAssertNil(recorder.rejected)
+        XCTAssertEqual(plugin.states, ["paused"])
+        XCTAssertEqual(plugin.events.first?.data["id"] as? String, "")
+    }
+
+    func testPlayAndPauseBeforeStartResolve() {
+        let plugin = RecordingPlugin()
+        let playRecorder = CallRecorder()
+        let pauseRecorder = CallRecorder()
+
+        plugin.play(playRecorder.makeCall())
+        plugin.pause(pauseRecorder.makeCall())
+
+        XCTAssertTrue(playRecorder.answered)
+        XCTAssertTrue(pauseRecorder.answered)
+        XCTAssertEqual(plugin.states, ["playing", "paused"])
+    }
+
+    func testSelectNextAndPreviousBeforeStartReject() {
+        let plugin = RecordingPlugin()
+        let selectRecorder = CallRecorder()
+        let nextRecorder = CallRecorder()
+        let previousRecorder = CallRecorder()
+
+        plugin.select(selectRecorder.makeCall(["id": "1"]))
+        plugin.next(nextRecorder.makeCall())
+        plugin.previous(previousRecorder.makeCall())
+
+        XCTAssertEqual(selectRecorder.rejected, "could not switch to item with given id")
+        XCTAssertEqual(nextRecorder.rejected, "could not switch to next item")
+        XCTAssertEqual(previousRecorder.rejected, "could not switch to previous item")
+    }
+
+    func testSetEarpieceAndSetSpeakerBeforeStartResolve() {
+        let plugin = RecordingPlugin()
+        let earpieceRecorder = CallRecorder()
+        let speakerRecorder = CallRecorder()
+
+        plugin.setEarpiece(earpieceRecorder.makeCall())
+        plugin.setSpeaker(speakerRecorder.makeCall())
+
+        XCTAssertTrue(earpieceRecorder.answered)
+        XCTAssertTrue(speakerRecorder.answered)
+    }
+
+    func testGetPositionAndGetDurationBeforeStartReturnZero() {
+        let plugin = RecordingPlugin()
+        let positionRecorder = CallRecorder()
+        let durationRecorder = CallRecorder()
+
+        plugin.getPosition(positionRecorder.makeCall())
+        plugin.getDuration(durationRecorder.makeCall())
+
+        XCTAssertEqual(positionRecorder.resolved?["value"] as? Int, 0)
+        XCTAssertEqual(durationRecorder.resolved?["value"] as? Int, 0)
+    }
+
+    func testStartWithEmptyItemsRejects() {
+        let plugin = RecordingPlugin()
+        let recorder = CallRecorder()
+
+        plugin.start(recorder.makeCall(["items": []]))
+
+        XCTAssertEqual(recorder.rejected, "could not load audio items")
+    }
+
+    func testStartWithoutAnItemsKeyRejects() {
+        let plugin = RecordingPlugin()
+        let recorder = CallRecorder()
+
+        plugin.start(recorder.makeCall())
+
+        XCTAssertEqual(recorder.rejected, "could not load audio items")
+    }
+
+    // MARK: - start() with real files
+
+    func testStartResolvesWithTheFirstItemId() throws {
+        let audio = try writeAudioFile(at: "first.wav")
+        let plugin = RecordingPlugin()
+        let recorder = CallRecorder()
+
+        plugin.start(recorder.makeCall(["items": [item(id: "1", audio: audio)]]))
+
+        XCTAssertNil(recorder.rejected)
+        XCTAssertEqual(recorder.resolved?["id"] as? String, "1")
+    }
+
+    /// The uri used to be reduced to its last path component and re-rooted in the
+    /// documents directory, so anything but a flat Directory.Data file failed.
+    func testStartResolvesUrisPointingOutsideTheDocumentsDirectory() throws {
+        let audio = try writeAudioFile(at: "nested/deeper/track.wav")
+        let plugin = RecordingPlugin()
+        let recorder = CallRecorder()
+
+        plugin.start(recorder.makeCall(["items": [item(id: "nested", audio: audio)]]))
+
+        XCTAssertNil(recorder.rejected)
+        XCTAssertEqual(recorder.resolved?["id"] as? String, "nested")
+    }
+
+    func testStartAcceptsAPlainPathAsWellAsAFileUrl() throws {
+        let audio = try writeAudioFile(at: "plain.wav")
+        let plugin = RecordingPlugin()
+        let recorder = CallRecorder()
+
+        plugin.start(recorder.makeCall(["items": [[
+            "id": "plain",
+            "title": "Plain",
+            "subtitle": "Path",
+            "audioUri": audio.path,
+            "imageUri": ""
+        ]]]))
+
+        XCTAssertNil(recorder.rejected)
+        XCTAssertEqual(recorder.resolved?["id"] as? String, "plain")
+    }
+
+    func testStartRejectsWhenTheAudioFileIsMissing() {
+        let plugin = RecordingPlugin()
+        let recorder = CallRecorder()
+        let missing = sandbox.appendingPathComponent("gone.wav")
+
+        plugin.start(recorder.makeCall(["items": [item(id: "1", audio: missing)]]))
+
+        XCTAssertEqual(recorder.rejected, "could not load audio items")
+    }
+
+    // MARK: - Lock screen metadata
+
+    func testNowPlayingInfoUsesTheCurrentItemMetadata() throws {
+        let audio = try writeAudioFile(at: "meta.wav")
+        let image = try writeImageFile(at: "meta.png")
+        let plugin = RecordingPlugin()
+
+        plugin.start(CallRecorder().makeCall(["items": [item(id: "1", audio: audio, image: image)]]))
+
+        let info = MPNowPlayingInfoCenter.default().nowPlayingInfo
+        XCTAssertEqual(info?[MPMediaItemPropertyTitle] as? String, "Title 1")
+        XCTAssertEqual(info?[MPMediaItemPropertyArtist] as? String, "Subtitle 1")
+        XCTAssertNotNil(info?[MPMediaItemPropertyArtwork])
+    }
+
+    /// The artwork request handler used to force unwrap UIImage(contentsOfFile:),
+    /// which crashed on an arbitrary thread whenever the system asked for it.
+    func testStartOmitsArtworkWhenTheImageIsMissing() throws {
+        let audio = try writeAudioFile(at: "no-art.wav")
+        let plugin = RecordingPlugin()
+        let recorder = CallRecorder()
+
+        plugin.start(recorder.makeCall(["items": [item(id: "1", audio: audio)]]))
+
+        XCTAssertNil(recorder.rejected)
+        let info = MPNowPlayingInfoCenter.default().nowPlayingInfo
+        XCTAssertEqual(info?[MPMediaItemPropertyTitle] as? String, "Title 1")
+        XCTAssertNil(info?[MPMediaItemPropertyArtwork])
+    }
+
+    func testStopClearsNowPlayingInfo() throws {
+        let audio = try writeAudioFile(at: "clear.wav")
+        let plugin = RecordingPlugin()
+
+        plugin.start(CallRecorder().makeCall(["items": [item(id: "1", audio: audio)]]))
+        XCTAssertNotNil(MPNowPlayingInfoCenter.default().nowPlayingInfo)
+
+        plugin.stop(CallRecorder().makeCall())
+        XCTAssertNil(MPNowPlayingInfoCenter.default().nowPlayingInfo)
+    }
+
+    // MARK: - Lifetime
+    //
+    // The plugin used to be kept alive by two strong references: the onCompleted
+    // method reference stored on the player, and the five MPRemoteCommandCenter
+    // target blocks, which that process-wide singleton never releases.
+
+    func testPluginIsReleasedAfterStop() throws {
+        let audio = try writeAudioFile(at: "lifetime.wav")
+        weak var weakPlugin: RecordingPlugin?
+
+        autoreleasepool {
+            let plugin = RecordingPlugin()
+            weakPlugin = plugin
+
+            plugin.start(CallRecorder().makeCall(["items": [item(id: "1", audio: audio)]]))
+            plugin.stop(CallRecorder().makeCall())
+        }
+
+        XCTAssertNil(weakPlugin, "plugin leaked -- check [weak self] on onCompleted and the remote command targets")
+    }
+
+    func testPluginIsReleasedWithoutAnExplicitStop() throws {
+        let audio = try writeAudioFile(at: "lifetime-no-stop.wav")
+        weak var weakPlugin: RecordingPlugin?
+
+        autoreleasepool {
+            let plugin = RecordingPlugin()
+            weakPlugin = plugin
+
+            plugin.start(CallRecorder().makeCall(["items": [item(id: "1", audio: audio)]]))
+        }
+
+        XCTAssertNil(weakPlugin, "plugin leaked -- deinit has to drop the remote command targets")
+    }
+}

--- a/ios/Tests/NativeAudioPlayerPluginTests/NativeAudioPlayerPluginTests.swift
+++ b/ios/Tests/NativeAudioPlayerPluginTests/NativeAudioPlayerPluginTests.swift
@@ -322,6 +322,26 @@ class NativeAudioPlayerPluginTests: XCTestCase {
         XCTAssertNil(weakPlugin, "plugin leaked -- check [weak self] on onCompleted and the remote command targets")
     }
 
+    /// A failed start() replaces the player that was loaded, so the targets from the
+    /// previous start would be left driving a player nothing can reach any more.
+    func testFailedStartRemovesTheTargetsOfTheStartBeforeIt() throws {
+        let audio = try writeAudioFile(at: "failed-restart.wav")
+        let plugin = RecordingPlugin()
+
+        plugin.start(CallRecorder().makeCall(["items": [item(id: "1", audio: audio)]]))
+        XCTAssertNotNil(plugin.playTarget)
+
+        let recorder = CallRecorder()
+        plugin.start(recorder.makeCall(["items": []]))
+
+        XCTAssertEqual(recorder.rejected, "could not load audio items")
+        XCTAssertNil(plugin.pauseTarget)
+        XCTAssertNil(plugin.playTarget)
+        XCTAssertNil(plugin.nextTarget)
+        XCTAssertNil(plugin.previousTarget)
+        XCTAssertNil(plugin.seekTarget)
+    }
+
     func testPluginIsReleasedWithoutAnExplicitStop() throws {
         let audio = try writeAudioFile(at: "lifetime-no-stop.wav")
         weak var weakPlugin: RecordingPlugin?

--- a/ios/Tests/NativeAudioPlayerPluginTests/NativeAudioPlayerTests.swift
+++ b/ios/Tests/NativeAudioPlayerPluginTests/NativeAudioPlayerTests.swift
@@ -1,4 +1,5 @@
 import XCTest
+import MediaPlayer
 @testable import NativeAudioPlayerPlugin
 
 class NativeAudioPlayerTests: XCTestCase {
@@ -97,5 +98,44 @@ class NativeAudioPlayerTests: XCTestCase {
 
         XCTAssertEqual(player.duration, 0)
         XCTAssertEqual(player.position, 0)
+    }
+
+    // The plugin holds a player over an empty item list until start() succeeds,
+    // so every accessor below has to stay reachable without a current item.
+
+    func testMetadataIsEmptyWithoutItems() {
+        let player = NativeAudioPlayer([])
+
+        XCTAssertNil(player.currentItem)
+        XCTAssertEqual(player.currentId, "")
+        XCTAssertEqual(player.title, "")
+        XCTAssertEqual(player.subtitle, "")
+    }
+
+    func testNavigationFailsWithoutItems() {
+        let player = NativeAudioPlayer([])
+
+        XCTAssertFalse(player.next())
+        XCTAssertFalse(player.previous())
+        XCTAssertFalse(player.select("1"))
+
+        // previous() used to land on index -1, which trapped on the next read
+        XCTAssertEqual(player.currentIndex, 0)
+    }
+
+    func testLoadFailsWithoutItems() {
+        XCTAssertFalse(NativeAudioPlayer([]).load())
+    }
+
+    func testLoadFailsForAnItemWithoutAnAudioUri() {
+        XCTAssertFalse(NativeAudioPlayer([["id": "1"]]).load())
+    }
+
+    func testInitLockScreenIsANoOpWithoutItems() {
+        MPNowPlayingInfoCenter.default().nowPlayingInfo = nil
+
+        NativeAudioPlayer([]).initLockScreen()
+
+        XCTAssertNil(MPNowPlayingInfoCenter.default().nowPlayingInfo)
     }
 }


### PR DESCRIPTION
Fixes a set of defects found while reviewing the iOS player against the Android implementation and the `src/definitions.ts` contract. Scope is deliberately limited to **crashes and leaks**, plus two behavior changes called out below. The remaining API divergences and the structural refactor are listed under *Deliberately out of scope*.

## iOS

**Crashes**

- Every method except `getPosition`/`getDuration` trapped when called before `start()`. The plugin holds `NativeAudioPlayer([])` from construction, and `currentId`/`title`/`subtitle` subscripted `playerItems[currentIndex]` unchecked — so `stop()` → `onPause()` → `notifyListeners(…, player.currentId)` indexed an empty array. These now read through a bounds-checked `currentItem`, and `select`/`next`/`previous` guard an empty playlist (`previous()` used to land on index `-1`).
- `start({items: []})` rejects instead of trapping.
- The lock screen artwork force unwrapped `UIImage(contentsOfFile:)!` inside a handler the system invokes lazily on an arbitrary thread, so any missing or undecodable `imageUri` crashed asynchronously. The image is now decoded up front and the artwork key omitted when it can't be loaded.

**Leaks**

- `player.onCompleted = self.onCompleted` stored an unapplied method reference capturing `self` strongly; the plugin owns the player, so this was a cycle.
- All five `addTarget` closures captured `self` strongly, and `MPRemoteCommandCenter.shared()` holds them for the lifetime of the app. Nothing removed them, and neither class had a `deinit`.
- `removeTarget(pauseTarget)` ran with `pauseTarget == nil` on the first `start()`. `removeTarget(nil)` is documented as *remove all targets*, so it wiped handlers registered by the host app or other Capacitor plugins.

**Behavior change:** `audioUri`/`imageUri` are now honored in full. Previously only `lastPathComponent` survived and was re-rooted in the documents directory — that worked only because Capacitor's `Directory.Data` maps to Documents on iOS, and broke for nested paths, `Directory.Cache` and `Directory.Library`. Android and `src/web.ts` both pass the URI through unchanged.

## Android

- `stop()` set `mediaController = null` *before* `unregisterPlayerEvents()`, whose own null guard then short-circuited — **the listener was never removed**.
- `stop()` logged and swallowed exceptions without resolving or rejecting, hanging the promise. It now always answers, and releases the controller in a separate block so a failed `pause()` can't leak it.
- A repeat `start()` overwrote `mediaController` without releasing the previous one, and the de-dupe `removeListener` was commented out — every `update` event was delivered twice.
- `MoreExecutors.directExecutor()` ran the callback on whichever thread completed the future, though `MediaController` is main-thread only. Now `ContextCompat.getMainExecutor`.
- `assert mediaItem != null` is disabled at runtime on Android; replaced with a real check, plus a guard for a transition delivered after the controller is gone.
- `getPosition()` resolved with `{}` when no controller existed, reaching JS as `undefined` where iOS and web return `0`.
- **Behavior change:** `select`/`next`/`previous` resolve with `{id}` as `definitions.ts` declares, instead of an empty object.

## Tests

Adds plugin-level suites on both platforms. `notifyListeners` and `resolve`/`reject` only touch state the plugin owns, so neither needs a bridge — iOS overrides `notifyListeners`, Android mocks `MessageHandler`.

Every new test was run against the **unfixed** sources first:

- **iOS** — the suite repeatedly killed the test process (`Fatal error: Index out of range` → `Restarting after unexpected exit, crash, or test timeout`), both retain-cycle tests reported `plugin leaked`, and the URI tests rejected.
- **Android** — 10 of 21 failed, one per fix.

`android/build.gradle` gains `org.mockito:mockito-core:5.20.0`. Every `MediaController` method the plugin calls is `final`, so Mockito 5's inline mock maker is what makes the `stop()`, repeat-`start()` and `{id}` fixes testable at all. It doesn't touch the AGP/Gradle/androidx pins that `CLAUDE.md` freezes to the Capacitor template.

One caveat worth stating: `testShouldReturnAnEmptyListForMalformedJson` passes against the old code too — the `JSONException` it triggers happens to carry a message, so the `Objects.requireNonNull(e.getMessage())` NPE-inside-the-catch doesn't fire. That fix is still correct, but the test is coverage rather than a regression pin.

## Verification

`npm run verify` passes end to end: iOS `** TEST SUCCEEDED **` (28 tests), Android `BUILD SUCCESSFUL` (22 tests), web build clean. Prettier and ESLint clean. SwiftLint reports 1 violation — a pre-existing missing trailing newline in `Package.swift`, left alone as out of scope.

Still worth a manual pass on device for the parts unit tests can't reach: lock screen controls after `start()`, and playback across a `setEarpiece()`/`setSpeaker()` round trip.

## Deliberately out of scope

Found during review, documented rather than fixed:

- **Data race.** `CapacitorBridge.swift:131,507` dispatch plugin calls on a background `"bridge"` queue while `MPRemoteCommandCenter` handlers fire on main; both mutate `currentIndex`, `audioPlayer` and `earpiece` unsynchronized, and `MPNowPlayingInfoCenter` is written off-main.
- `select()` with an unknown id resolves with the *wrong* id on iOS (the loop leaves the index untouched and `load()` still returns `true`). Web throws. `testSelectKeepsTheCurrentItemForAnUnknownId` still pins the current behavior.
- `stop()` doesn't clear the playlist on either native platform, contradicting `definitions.ts:24`.
- `load()`'s `catch` swallows the error and recursively retries with `earpiece = true`, so `setSpeaker()` can silently land on the earpiece and still resolve.
- `MPNowPlayingInfoPropertyPlaybackRate` is hardcoded to `1.0`, so the lock screen scrubber advances while paused; lock screen scrubbing bypasses `notifyListeners` entirely.
- Playback errors never reach JS on either platform (no `audioPlayerDecodeErrorDidOccur`, no `onPlayerError`).
- Position and duration are whole seconds natively; web returns fractional.

🤖 Generated with [Claude Code](https://claude.com/claude-code)