### PR TITLE
feat: report the playback the system stops on the app's behalf

### DIFF
--- a/.changeset/great-poets-clap.md
+++ b/.changeset/great-poets-clap.md
@@ -1,0 +1,14 @@
+---
+'@smartcompanion/native-audio-player': minor
+---
+
+Report the playback the system stops on the app's behalf. An incoming call, Siri, or another app taking the audio would stop the audio without a word, leaving an app that mirrors playback in its own UI showing a pause button for audio that was no longer running.
+
+No new state and no new event: an interruption is reported as `paused`, which is what it is, and which every app already handles. The `audioPlayerChange` event has always promised to report a change whoever caused it — an interruption is one more cause, alongside a lock screen control, a headset button and the audio running out.
+
+The player is not started again when the interruption ends, and nothing is reported then. That matches what an output change already does: resuming is the app's decision, made by calling `play()`.
+
+- **iOS** observes `AVAudioSession.interruptionNotification`. The system stops the player before it delivers the notification, so `isPlaying` cannot say whether anything was interrupted — the player now tracks whether playback was asked for, and only an interruption that stopped something is reported. The lock screen is put back to offering play, and the session is reactivated when the interruption ends, without which the following `play()` moved the playhead in silence.
+- **Android** hands the audio focus to media3, which stops playback when something else needs the audio. media3 would also start it again by itself once the focus came back, since a transient loss suppresses playback without withdrawing the request to play — that request is now withdrawn, so the plugin keeps to its promise not to resume on its own.
+
+Interruptions are not reported on the web: browsers expose nothing to observe them with.

--- a/README.md
+++ b/README.md
@@ -185,6 +185,7 @@ that actually happened, so a call that changes nothing stays silent.
 | An item reaches its end | `completed` | | The player stops, the item stays selected and position is set to 0. (no separate pause event) |
 | `NativeAudioPlayer.setEarpiece` `NativeAudioPlayer.setSpeaker` | `paused` | `earpiece` `speaker` | Only overrides the built-in output, and does nothing audible while headphones or Bluetooth are connected — the output event then keeps reporting `external` |
 | The user plugs in headphones, connects Bluetooth, or unplugs them | `paused` | `external` `earpiece` `speaker` | Playback always stops, so audio meant for the earpiece cannot carry on out loud through a different output. |
+| An incoming call, Siri, or another app takes the audio | `paused` | | Playback stops and stays stopped when the interruption ends — nothing is reported then, so call `play()` to carry on. Reported only when something was playing, and not reported on the web |
 
 Notes on the events themselves:
 
@@ -194,7 +195,10 @@ Notes on the events themselves:
   guaranteed to be the same on both platforms — treat them as two reports of one event, not a
   sequence.
 - Every event reports playback moving, whoever moved it: a call on this plugin, a lock screen
-  or notification control, a headset button, or the audio running out.
+  or notification control, a headset button, the audio running out, or the system stopping it
+  for something else.
+- The player is never started again on its own. Whatever stopped it — an output change or an
+  interruption — resuming is the app's decision, made by calling `play()`.
 
 ## Other Audio Player Plugins
 
@@ -565,8 +569,12 @@ state below behaves the same way on iOS, Android and the web.
 - `playing` -- playback started or resumed.
 - `paused` -- playback stopped and the position was kept. Emitted for a
   {@link NativeAudioPlayerPlugin.pause} call that stopped something, for a
-  {@link NativeAudioPlayerPlugin.stop} call whatever was happening, and for an output
-  change, but never for an item that reached its end: that is `completed`.
+  {@link NativeAudioPlayerPlugin.stop} call whatever was happening, for an output change, and
+  for an interruption -- an incoming call, or another app taking the audio -- that stopped
+  something, but never for an item that reached its end: that is `completed`. The player is
+  not started again when an interruption ends, and nothing is reported then, so an app that
+  wants to carry on has to call {@link NativeAudioPlayerPlugin.play} itself. Interruptions
+  are not reported on the web, where the browser exposes nothing to observe them with.
 - `skip` -- the selected item changed through {@link NativeAudioPlayerPlugin.next},
   {@link NativeAudioPlayerPlugin.previous} or {@link NativeAudioPlayerPlugin.select}. The new
   item is selected but not playing, so it takes a {@link NativeAudioPlayerPlugin.play} to

--- a/android/src/main/java/app/smartcompanion/audio/AudioPlayerService.java
+++ b/android/src/main/java/app/smartcompanion/audio/AudioPlayerService.java
@@ -93,7 +93,11 @@ public class AudioPlayerService extends MediaSessionService {
             // callback arrives once the next item is already being rendered, so the first
             // milliseconds of it are audible before the pause lands.
             .setPauseAtEndOfMediaItems(true)
-            .setAudioAttributes(getAudioAttributes(channel), false)
+            // let media3 hold the audio focus, so an incoming call or another app taking the
+            // audio stops playback instead of talking over it. What it does on the way back is
+            // undone in NativeAudioPlayerPlugin#onIsPlayingChanged -- this plugin never resumes
+            // on its own.
+            .setAudioAttributes(getAudioAttributes(channel), true)
             // pause when the audio would fall back to the speaker on its own, e.g. when
             // headphones are unplugged. The plugin pauses on every output change anyway,
             // but this happens inside the audio framework and so beats the device callback

--- a/android/src/main/java/app/smartcompanion/audio/NativeAudioPlayerPlugin.java
+++ b/android/src/main/java/app/smartcompanion/audio/NativeAudioPlayerPlugin.java
@@ -149,8 +149,28 @@ public class NativeAudioPlayerPlugin extends Plugin {
             }
         }
 
+        /**
+         * Reports playback starting and stopping, whoever asked for it -- including the audio
+         * framework, which stops it when something else needs the audio.
+         */
         @Override
         public void onIsPlayingChanged(boolean isPlaying) {
+            MediaController controller = mediaController;
+
+            // an update can still be delivered once the controller is gone
+            if (controller == null) {
+                return;
+            }
+
+            // A transient focus loss -- an incoming call, or another app briefly taking the
+            // audio -- suppresses playback without clearing playWhenReady, so media3 starts
+            // again by itself once focus comes back. The plugin does not resume on its own, so
+            // the request to play is withdrawn here and the app decides. isPlaying already
+            // reads false, so this raises no second event of its own.
+            if (!isPlaying && controller.getPlaybackSuppressionReason() == Player.PLAYBACK_SUPPRESSION_REASON_TRANSIENT_AUDIO_FOCUS_LOSS) {
+                controller.pause();
+            }
+
             // the stop at an item boundary is reported as completed, by onPlayWhenReadyChanged
             // just above -- which the player delivers before this one for the same update
             if (!isPlaying && pausedEventAlreadySent) {
@@ -161,7 +181,7 @@ public class NativeAudioPlayerPlugin extends Plugin {
             try {
                 JSObject json = nativeAudioPlayer.preparePlayerEvent(
                     isPlaying ? "playing" : "paused",
-                    Objects.requireNonNull(mediaController.getCurrentMediaItem())
+                    Objects.requireNonNull(controller.getCurrentMediaItem())
                 );
                 notifyListeners("audioPlayerChange", json);
             } catch (Exception e) {

--- a/android/src/test/java/app/smartcompanion/audio/NativeAudioPlayerPluginTest.java
+++ b/android/src/test/java/app/smartcompanion/audio/NativeAudioPlayerPluginTest.java
@@ -375,6 +375,68 @@ public class NativeAudioPlayerPluginTest {
         Assert.assertEquals("paused", recording.events.get(0).getString("state"));
     }
 
+    // An interruption -- an incoming call, or another app briefly taking the audio -- suppresses
+    // playback without clearing playWhenReady, so media3 would start again by itself once it has
+    // the focus back. The plugin does not resume on its own, see AudioPlayerState in
+    // definitions.ts, so the request to play has to be withdrawn.
+
+    @Test
+    public void testAnInterruptionWithdrawsTheRequestToPlay() {
+        MediaController controller = controllerWithCurrentItem("item1");
+        when(controller.getPlaybackSuppressionReason()).thenReturn(Player.PLAYBACK_SUPPRESSION_REASON_TRANSIENT_AUDIO_FOCUS_LOSS);
+        plugin.mediaController = controller;
+
+        plugin.playerListener.onIsPlayingChanged(false);
+
+        verify(controller).pause();
+    }
+
+    @Test
+    public void testAnInterruptionIsReportedAsAPause() {
+        RecordingPlugin recording = new RecordingPlugin();
+        MediaController controller = controllerWithCurrentItem("item1");
+        when(controller.getPlaybackSuppressionReason()).thenReturn(Player.PLAYBACK_SUPPRESSION_REASON_TRANSIENT_AUDIO_FOCUS_LOSS);
+        recording.mediaController = controller;
+
+        recording.playerListener.onIsPlayingChanged(false);
+
+        // one event for one transition -- withdrawing the request to play must not add a second
+        Assert.assertEquals(1, recording.events.size());
+        Assert.assertEquals("paused", recording.events.get(0).getString("state"));
+        Assert.assertEquals("item1", recording.events.get(0).getString("id"));
+    }
+
+    @Test
+    public void testAnOrdinaryPauseIsNotWithdrawnAgain() {
+        MediaController controller = controllerWithCurrentItem("item1");
+        when(controller.getPlaybackSuppressionReason()).thenReturn(Player.PLAYBACK_SUPPRESSION_REASON_NONE);
+        plugin.mediaController = controller;
+
+        plugin.playerListener.onIsPlayingChanged(false);
+
+        verify(controller, never()).pause();
+    }
+
+    @Test
+    public void testPlaybackStartingIsNotWithdrawn() {
+        MediaController controller = controllerWithCurrentItem("item1");
+        when(controller.getPlaybackSuppressionReason()).thenReturn(Player.PLAYBACK_SUPPRESSION_REASON_TRANSIENT_AUDIO_FOCUS_LOSS);
+        plugin.mediaController = controller;
+
+        plugin.playerListener.onIsPlayingChanged(true);
+
+        verify(controller, never()).pause();
+    }
+
+    @Test
+    public void testAPlaybackChangeWithoutAControllerIsIgnored() {
+        plugin.mediaController = null;
+
+        // an update can still be delivered once the controller is gone -- this used to
+        // dereference it and throw into the catch below
+        plugin.playerListener.onIsPlayingChanged(false);
+    }
+
     // A second start() used to leave the previous listener attached, so every
     // audioPlayerChange event was delivered twice.
 

--- a/ios/Sources/NativeAudioPlayerPlugin/NativeAudioPlayer.swift
+++ b/ios/Sources/NativeAudioPlayerPlugin/NativeAudioPlayer.swift
@@ -10,6 +10,13 @@ import UIKit
     var currentIndex: Int = 0
     var earpiece: Bool = true
 
+    /// Whether playback was asked for, which is not the same as whether it is happening.
+    ///
+    /// The system stops the player before it delivers an interruption, so `isPlaying` reads
+    /// false by the time the notification arrives and cannot say whether anything was actually
+    /// interrupted. This is the answer to that question, and nothing else should be read for it.
+    var playWhenReady: Bool = false
+
     // the item currentIndex points at, or nil while the playlist is empty --
     // everything below reads through this so an unset playlist cannot trap
     var currentItem: AudioPlayerItem? {
@@ -42,6 +49,10 @@ import UIKit
     var onCompleted: ((_ id: String) -> Void)?
 
     var onAudioOutputChanged: ((_ output: String) -> Void)?
+
+    /// Called when something outside the app stopped playback that was running -- an incoming
+    /// call, Siri, or another app taking the audio session.
+    var onInterrupted: (() -> Void)?
 
     /// The output the session is routed to right now, which is not necessarily the one that
     /// was requested: the earpiece/speaker override is skipped while an external device is
@@ -165,6 +176,7 @@ import UIKit
             try audioSession.setActive(true, options: .notifyOthersOnDeactivation)
 
             audioPlayer?.stop()
+            playWhenReady = false
             audioPlayer = try AVAudioPlayer(contentsOf: url)
             audioPlayer?.prepareToPlay()
             audioPlayer?.delegate = self
@@ -185,6 +197,7 @@ import UIKit
     func stop() {
         audioPlayer?.stop()
         audioPlayer = nil
+        playWhenReady = false
 
         // remove player from lock screen
         try? AVAudioSession.sharedInstance().setActive(false, options: .notifyOthersOnDeactivation)
@@ -193,12 +206,18 @@ import UIKit
 
     func play() {
         if audioPlayer?.isPlaying == false {
+            playWhenReady = true
             audioPlayer?.play()
             updateLockScreen()
         }
     }
 
     func pause() {
+        // outside the guard: a player the system already stopped is still one nobody is asking
+        // to play, and leaving this set would have the next interruption report a pause that
+        // interrupted nothing
+        playWhenReady = false
+
         if audioPlayer?.isPlaying == true {
             audioPlayer?.pause()
             updateLockScreen()
@@ -321,6 +340,10 @@ import UIKit
 
     public func audioPlayerDidFinishPlaying(_ player: AVAudioPlayer, successfully flag: Bool) {
         if flag {
+            // the item ran out, so nothing is asking for playback any more -- left set, the
+            // next interruption would report a pause that interrupted nothing
+            playWhenReady = false
+
             // an item that played out has to be ready to play again, rather than parked at its
             // end where play() would have nothing left to play -- see AudioPlayerState in
             // definitions.ts. This also puts the lock screen back to the start of the item.

--- a/ios/Sources/NativeAudioPlayerPlugin/NativeAudioPlayerInterruptions.swift
+++ b/ios/Sources/NativeAudioPlayerPlugin/NativeAudioPlayerInterruptions.swift
@@ -1,0 +1,60 @@
+import Foundation
+import AVFoundation
+
+/// Playback the system stops on the app's behalf: an incoming call, Siri, or another app taking
+/// the audio session.
+///
+/// Kept apart from the player itself: none of this is a transition anybody asked for, and the
+/// session has to be put back together afterwards before the player can be used again.
+extension NativeAudioPlayer {
+
+    /// Starts reporting interruptions. Removes before adding, the way `observeAudioOutput` does,
+    /// so a second `start()` cannot register the same observer twice.
+    func observeInterruptions() {
+        NotificationCenter.default.removeObserver(self, name: AVAudioSession.interruptionNotification, object: nil)
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(handleInterruption),
+            name: AVAudioSession.interruptionNotification,
+            object: nil
+        )
+    }
+
+    @objc func handleInterruption(_ notification: Notification) {
+        guard let rawType = notification.userInfo?[AVAudioSessionInterruptionTypeKey] as? UInt,
+              let type = AVAudioSession.InterruptionType(rawValue: rawType) else {
+            return
+        }
+
+        switch type {
+        case .began:
+            interruptionBegan()
+        case .ended:
+            // the interruption deactivated the session and play() does not activate one, so
+            // without this the next play() moves the playhead in silence. The .shouldResume
+            // hint is deliberately ignored: playback is not resumed on its own, see
+            // AudioPlayerState in definitions.ts.
+            try? AVAudioSession.sharedInstance().setActive(true, options: .notifyOthersOnDeactivation)
+        @unknown default:
+            break
+        }
+    }
+
+    private func interruptionBegan() {
+        // the system has already stopped the player, so isPlaying cannot say whether this
+        // interrupted anything -- playWhenReady is what was actually asked for
+        let wasPlaying = playWhenReady
+
+        audioPlayer?.pause()
+        playWhenReady = false
+
+        // explicitly, rather than through pause(): its guard is on isPlaying, which the system
+        // has already cleared, so the lock screen would keep a rate of 1.0 and go on offering
+        // pause for audio that is not running
+        updateLockScreen()
+
+        if wasPlaying {
+            onInterrupted?()
+        }
+    }
+}

--- a/ios/Sources/NativeAudioPlayerPlugin/NativeAudioPlayerPlugin.swift
+++ b/ios/Sources/NativeAudioPlayerPlugin/NativeAudioPlayerPlugin.swift
@@ -49,9 +49,13 @@ public class NativeAudioPlayerPlugin: CAPPlugin, CAPBridgedPlugin {
         player.onAudioOutputChanged = { [weak self] output in
             self?.onAudioOutputChanged(output)
         }
+        player.onInterrupted = { [weak self] in
+            self?.onInterrupted()
+        }
 
         if player.load() {
             player.observeAudioOutput()
+            player.observeInterruptions()
 
             let commandCenter = MPRemoteCommandCenter.shared()
 
@@ -352,6 +356,15 @@ extension NativeAudioPlayerPlugin {
         } else {
             return false
         }
+    }
+
+    /// Reports the playback the system stopped on the app's behalf.
+    ///
+    /// The player half of this is already done by the time it gets here, so this only announces
+    /// it -- going through onPause() would pause a player that is not running and report a
+    /// change that did not happen.
+    private func onInterrupted() {
+        self.notifyListeners("audioPlayerChange", data: ["id": player.currentId, "state": "paused"])
     }
 
     private func onCompleted(_ id: String) {

--- a/ios/Tests/NativeAudioPlayerPluginTests/NativeAudioPlayerTests.swift
+++ b/ios/Tests/NativeAudioPlayerPluginTests/NativeAudioPlayerTests.swift
@@ -199,4 +199,89 @@ class NativeAudioPlayerTests: PluginTestCase {
 
         XCTAssertEqual(reported.count, 2)
     }
+
+    // An interruption -- an incoming call, Siri, or another app taking the audio session --
+    // stops playback and is reported as a pause. It is never resumed on its own, see
+    // AudioPlayerState in definitions.ts.
+
+    private func postInterruption(_ type: AVAudioSession.InterruptionType, options: AVAudioSession.InterruptionOptions = []) {
+        NotificationCenter.default.post(
+            name: AVAudioSession.interruptionNotification,
+            object: AVAudioSession.sharedInstance(),
+            userInfo: [
+                AVAudioSessionInterruptionTypeKey: type.rawValue,
+                AVAudioSessionInterruptionOptionKey: options.rawValue
+            ]
+        )
+    }
+
+    func testAnInterruptionReportsThePlaybackItStopped() throws {
+        let audio = try writeAudioFile(at: "interrupted.wav", seconds: 5)
+        let player = NativeAudioPlayer([["id": "1", "audioUri": audio.absoluteString]])
+        var interruptions = 0
+        player.onInterrupted = { interruptions += 1 }
+
+        XCTAssertTrue(player.load())
+        player.observeInterruptions()
+        player.play()
+        XCTAssertTrue(player.playWhenReady)
+
+        postInterruption(.began)
+
+        XCTAssertEqual(interruptions, 1)
+        XCTAssertFalse(player.playWhenReady)
+        XCTAssertEqual(player.audioPlayer?.isPlaying, false)
+    }
+
+    func testAnInterruptionOfAPausedPlayerReportsNothing() throws {
+        let audio = try writeAudioFile(at: "not-playing.wav", seconds: 5)
+        let player = NativeAudioPlayer([["id": "1", "audioUri": audio.absoluteString]])
+        var interruptions = 0
+        player.onInterrupted = { interruptions += 1 }
+
+        XCTAssertTrue(player.load())
+        player.observeInterruptions()
+
+        // nothing was playing, so nothing was interrupted -- a state is reported per change,
+        // and this one changed nothing
+        postInterruption(.began)
+
+        XCTAssertEqual(interruptions, 0)
+    }
+
+    func testAnInterruptionThatEndsDoesNotResume() throws {
+        let audio = try writeAudioFile(at: "resumable.wav", seconds: 5)
+        let player = NativeAudioPlayer([["id": "1", "audioUri": audio.absoluteString]])
+        var interruptions = 0
+        player.onInterrupted = { interruptions += 1 }
+
+        XCTAssertTrue(player.load())
+        player.observeInterruptions()
+        player.play()
+
+        postInterruption(.began)
+        // the system asks for playback back, and is deliberately not given it -- resuming is
+        // left to the app, the way it is for an output change
+        postInterruption(.ended, options: .shouldResume)
+
+        XCTAssertEqual(interruptions, 1)
+        XCTAssertFalse(player.playWhenReady)
+        XCTAssertEqual(player.audioPlayer?.isPlaying, false)
+    }
+
+    func testANotificationWithoutAnInterruptionTypeIsIgnored() throws {
+        let audio = try writeAudioFile(at: "malformed.wav", seconds: 5)
+        let player = NativeAudioPlayer([["id": "1", "audioUri": audio.absoluteString]])
+        var interruptions = 0
+        player.onInterrupted = { interruptions += 1 }
+
+        XCTAssertTrue(player.load())
+        player.observeInterruptions()
+        player.play()
+
+        NotificationCenter.default.post(name: AVAudioSession.interruptionNotification, object: nil)
+
+        XCTAssertEqual(interruptions, 0)
+        XCTAssertTrue(player.playWhenReady)
+    }
 }

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -166,8 +166,12 @@ export interface NativeAudioPlayerPlugin {
  * - `playing` -- playback started or resumed.
  * - `paused` -- playback stopped and the position was kept. Emitted for a
  *   {@link NativeAudioPlayerPlugin.pause} call that stopped something, for a
- *   {@link NativeAudioPlayerPlugin.stop} call whatever was happening, and for an output
- *   change, but never for an item that reached its end: that is `completed`.
+ *   {@link NativeAudioPlayerPlugin.stop} call whatever was happening, for an output change, and
+ *   for an interruption -- an incoming call, or another app taking the audio -- that stopped
+ *   something, but never for an item that reached its end: that is `completed`. The player is
+ *   not started again when an interruption ends, and nothing is reported then, so an app that
+ *   wants to carry on has to call {@link NativeAudioPlayerPlugin.play} itself. Interruptions
+ *   are not reported on the web, where the browser exposes nothing to observe them with.
  * - `skip` -- the selected item changed through {@link NativeAudioPlayerPlugin.next},
  *   {@link NativeAudioPlayerPlugin.previous} or {@link NativeAudioPlayerPlugin.select}. The new
  *   item is selected but not playing, so it takes a {@link NativeAudioPlayerPlugin.play} to


### PR DESCRIPTION
Closes #43.

An incoming call, Siri, or another app taking the audio stopped playback without a word, leaving an app that mirrors the player in its own UI showing a pause button for audio that was no longer running.

## No new event

An interruption is reported as `paused`, which is what it is, and which every app already handles. `audioPlayerChange` has always promised to report a change whoever caused it — an interruption is one more cause, alongside a lock screen control, a headset button and the audio running out.

A new `interrupted` state would also have broken the promise in `AudioPlayerState` that every state behaves the same on iOS, Android and the web: browsers expose nothing to observe an interruption with, so it would simply never have fired there.

The player is **not** started again when the interruption ends, and nothing is reported then. That matches what an output change already does: resuming is the app's decision, made by calling `play()`.

## iOS

Observes `AVAudioSession.interruptionNotification`, in a new `NativeAudioPlayerInterruptions.swift` — folding it into `NativeAudioPlayer.swift` pushed that file over SwiftLint's `file_length` and `type_body_length` limits.

The system stops the player *before* it delivers the notification, so `isPlaying` cannot say whether anything was interrupted. The player now tracks whether playback was asked for (`playWhenReady`, the same shape as Android's), and only an interruption that stopped something is reported. The lock screen is explicitly put back to offering play, and the session is reactivated on `.ended` — without that, the following `play()` moved the playhead in silence. The `.shouldResume` hint is deliberately ignored.

## Android

media3 now holds the audio focus (`setAudioAttributes(..., true)`). The catch is that a *transient* loss suppresses playback without clearing `playWhenReady`, so media3 would start again by itself once the focus came back. `onIsPlayingChanged` withdraws that request when it sees `PLAYBACK_SUPPRESSION_REASON_TRANSIENT_AUDIO_FOCUS_LOSS`; `isPlaying` is already false there, so it adds no second event. That handler also picked up the null-controller guard the two above it already had.

Headphone unplug was already handled on both platforms and is untouched.

## Verification

`npm run verify` and `npm run lint` both pass — iOS 48 tests, Android 53, web 38, 0 SwiftLint violations.

**Still needs a device.** The unit tests drive the listeners directly (mocked `MediaController` on Android, a synthetic notification on iOS), so they prove the plugin asks for the right thing, not that the audio framework does what is described above:

- [ ] Android emulator: play, `adb emu gsm call 5551234` → UI flips to paused. `adb emu gsm cancel` → **audio must stay stopped** (this is the assertion that the auto-resume cancellation works).
- [ ] iOS device: real call or Siri → paused. After it ends, the play button must produce *audible* sound.
- [ ] Both: `setEarpiece`/`setSpeaker` while playing. Android now requests focus per player and the channel switch rebuilds the ExoPlayer, so confirm the swap does not emit a spurious extra `paused`.
- [ ] Both: unplug headphones while playing — should behave exactly as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)